### PR TITLE
Resize player based on actual player size

### DIFF
--- a/src/main/java/com/fuzs/fivefeetsmall/config/ConfigHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/config/ConfigHandler.java
@@ -29,7 +29,7 @@ public class ConfigHandler {
 	public static double sneakingEyes = 1.27;
 
 	@Config.Name("Adjust Size")
-	@Config.Comment("Force the player to stay in sneaking position when the available space is less than 1.8 blocks (default player height) tall.")
+	@Config.Comment("Force the player to stay in sneaking position when there is not enough space to stand up.")
 	public static boolean adjustSize = true;
 
 	@SubscribeEvent

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
@@ -16,8 +16,13 @@ public class ClientEventHandler {
         }
 
         EntityPlayer player = evt.getEntityPlayer();
+        String uuid = player.getPersistentID().toString();
+
+        float height = CommonEventHandler.height.get(uuid);
+        float width = CommonEventHandler.width.get(uuid);
+
         AxisAlignedBB axisalignedbb = player.getEntityBoundingBox();
-        axisalignedbb = new AxisAlignedBB(axisalignedbb.minX, axisalignedbb.minY, axisalignedbb.minZ, axisalignedbb.minX + 0.6, axisalignedbb.minY + 1.8, axisalignedbb.minZ + 0.6);
+        axisalignedbb = new AxisAlignedBB(axisalignedbb.minX, axisalignedbb.minY, axisalignedbb.minZ, axisalignedbb.minX + width, axisalignedbb.minY + height, axisalignedbb.minZ + width);
 
         if (!player.isSneaking() && this.isSneakingPose(player) && player.world.collidesWithAnyBlock(axisalignedbb)) {
 

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
@@ -30,7 +30,7 @@ public class ClientEventHandler {
     }
 
     private boolean isSneakingPose(EntityPlayer player) {
-        String uuid = player.getUniqueID().toString();
+        String uuid = player.getPersistentID().toString();
 
         boolean flag = Math.abs(player.width - ConfigHandler.sneakingWidth / 0.6F * CommonEventHandler.width.get(uuid)) < 0.01F;
         boolean flag1 = Math.abs(player.height - ConfigHandler.sneakingHeight / 1.8F * CommonEventHandler.height.get(uuid)) < 0.01F;

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/ClientEventHandler.java
@@ -30,8 +30,10 @@ public class ClientEventHandler {
     }
 
     private boolean isSneakingPose(EntityPlayer player) {
-        boolean flag = Math.abs(player.width - ConfigHandler.sneakingWidth) < 0.01F;
-        boolean flag1 = Math.abs(player.height - ConfigHandler.sneakingHeight) < 0.01F;
+        String uuid = player.getUniqueID().toString();
+
+        boolean flag = Math.abs(player.width - ConfigHandler.sneakingWidth / 0.6F * CommonEventHandler.width.get(uuid)) < 0.01F;
+        boolean flag1 = Math.abs(player.height - ConfigHandler.sneakingHeight / 1.8F * CommonEventHandler.height.get(uuid)) < 0.01F;
         return flag && flag1;
     }
 

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
@@ -18,15 +18,13 @@ public class CommonEventHandler implements IPrivateAccessor {
     static HashMap<String, Float> width = new HashMap<>();
     static HashMap<String, Float> eyeHeight = new HashMap<>();
 
-    String uuid;
-
     @SubscribeEvent(priority = LOWEST)
     public void adjustSneakingSize(TickEvent.PlayerTickEvent event)
     {
 
         EntityPlayer player = event.player;
 
-        uuid = player.getPersistentID().toString();
+        String uuid = player.getPersistentID().toString();
 
         if (eyeHeight.get(uuid) != null) {
 

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
@@ -8,19 +8,38 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+
+import static net.minecraftforge.fml.common.eventhandler.EventPriority.LOWEST;
 
 public class CommonEventHandler implements IPrivateAccessor {
 
-    @SubscribeEvent
-    public void adjustSneakingSize(TickEvent.PlayerTickEvent event) {
+    static HashMap<String, Float> height = new HashMap<>();
+    static HashMap<String, Float> width = new HashMap<>();
+    static HashMap<String, Float> eyeHeight = new HashMap<>();
+
+    String uuid;
+
+    @SubscribeEvent(priority = LOWEST)
+    public void adjustSneakingSize(TickEvent.PlayerTickEvent event)
+    {
 
         EntityPlayer player = event.player;
 
+        uuid = player.getUniqueID().toString();
+
+        if (!player.isSneaking()) {
+
+            height.put(uuid, player.height);
+            width.put(uuid, player.width);
+            eyeHeight.put(uuid, player.eyeHeight);
+        }
+
         if (player.isSneaking()) {
 
-            player.height = (float) ConfigHandler.sneakingHeight;
-            player.width = (float) ConfigHandler.sneakingWidth;
-            player.eyeHeight = (float) ConfigHandler.sneakingEyes;
+            player.height = (float) ConfigHandler.sneakingHeight / 1.8F * height.get(uuid);
+            player.width = (float) ConfigHandler.sneakingWidth / 0.6F * width.get(uuid);
+            player.eyeHeight = (float) ConfigHandler.sneakingEyes / 1.62F * eyeHeight.get(uuid);
 
             try {
                 this.findSetSize().invoke(player, player.width, player.height);

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
@@ -28,6 +28,14 @@ public class CommonEventHandler implements IPrivateAccessor {
 
         uuid = player.getPersistentID().toString();
 
+        if (eyeHeight.get(uuid) != null) {
+
+            if (!player.isSneaking() && Math.abs(player.eyeHeight - (float) ConfigHandler.sneakingEyes / 1.62F * eyeHeight.get(uuid)) < 0.01F) {
+                player.eyeHeight = player.getDefaultEyeHeight();
+
+            }
+        }
+
         if (!player.isSneaking()) {
 
             height.put(uuid, player.height);
@@ -52,10 +60,6 @@ public class CommonEventHandler implements IPrivateAccessor {
                     player.posZ - player.width / 2.0D, player.posX + player.width / 2.0D,
                     axisalignedbb.minY + player.height, player.posZ + player.width / 2.0D);
             player.setEntityBoundingBox(axisalignedbb);
-
-        } else if (player.eyeHeight == (float) ConfigHandler.sneakingEyes) {
-
-            player.eyeHeight = player.getDefaultEyeHeight();
 
         }
     }

--- a/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
+++ b/src/main/java/com/fuzs/fivefeetsmall/handler/CommonEventHandler.java
@@ -26,7 +26,7 @@ public class CommonEventHandler implements IPrivateAccessor {
 
         EntityPlayer player = event.player;
 
-        uuid = player.getUniqueID().toString();
+        uuid = player.getPersistentID().toString();
 
         if (!player.isSneaking()) {
 


### PR DESCRIPTION
This allows this mod to work with mods that change the size of the player.
In my testing I used [Artifacts](https://minecraft.curseforge.com/projects/artifacts)' "Tiny Shirt", which uses [ArtemisLib](https://minecraft.curseforge.com/projects/artemislib) to resize the player.

In order to do this I keep track of every player's last non-sneaking height, width and eye-height and then scale using the ratio of the configured sneaking values and the vanilla non-sneaking values.