### PR TITLE
Modern vanilla linear fog rendering & Fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: |
-          8
-          17
+        java-version: 25
         cache: 'gradle'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Validate gradle wrapper checksum
-      uses: gradle/wrapper-validation-action@v1
+    - uses: actions/checkout@v6
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 25
@@ -22,7 +20,10 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew --no-daemon --stacktrace build
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: aqua-acrobatics
-        path: build/libs
+        path: |
+          build/libs/AquaAcrobatics-*.jar
+          !build/libs/AquaAcrobatics-*-*.jar
+        archive: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: |
-          8
-          17
+        java-version: 25
         cache: 'gradle'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,10 @@ tasks.named("compileJava", JavaCompile).configure {
     ]
 }
 
+tasks.named("javadoc", Javadoc).configure {
+    options.addStringOption("tag", "reason:a:Reason:")
+}
+
 processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "mod_id", project.ext.id

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
     id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
     id("eclipse")
-    id("com.gtnewhorizons.retrofuturagradle") version "1.4.2"
+    id('com.gtnewhorizons.retrofuturagradle') version '2.0.2'
     id("com.matthewprenger.cursegradle") version "1.4.0"
 }
 
@@ -28,7 +28,6 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
         // Azul covers the most platforms for Java 8 toolchains, crucially including MacOS arm64
-        vendor.set(org.gradle.jvm.toolchain.JvmVendorSpec.AZUL)
     }
     // Generate sources and javadocs jars when building and publishing
     withSourcesJar()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx3G -Dfile.encoding=GBK
 org.gradle.daemon=true
 
 # environment

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G -Dfile.encoding=GBK
+org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=true
 
 # environment

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         maven {
             // RetroFuturaGradle
             name = "GTNH Maven"
-            url = uri("http://jenkins.usrv.eu:8081/nexus/content/groups/public/")
+            url = uri("https://nexus.gtnewhorizons.com/repository/public/")
             allowInsecureProtocol = true
             mavenContent {
                 includeGroup("com.gtnewhorizons")
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     // Automatic toolchain provisioning
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "${mod_name.replaceAll("\\s", "")}"

--- a/src/main/java/com/fuzs/aquaacrobatics/biome/BiomeWaterFogColors.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/biome/BiomeWaterFogColors.java
@@ -16,7 +16,7 @@ public abstract class BiomeWaterFogColors {
     private static final int PERCEIVED_WATER_COLOR_112 = 0x2b3bf4;
     private static final HashMap<ResourceLocation, Integer> fogColorMap = new HashMap<>();
     private static final HashMap<ResourceLocation, Integer> baseColorMap = new HashMap<>();
-   
+
     private static final String[] DEFAULT_COLORS = {
             "minecraft:mutated_swampland,6388580,2302743",
             "minecraft:swampland,6388580,2302743",
@@ -72,7 +72,7 @@ public abstract class BiomeWaterFogColors {
             "thaumcraft:magical_forest,3035999,",
             "thaumcraft:eerie,3035999,"
     };
-    
+
     private static int emulateLegacyColor(int modColor) {
         int modR = (modColor & 0xff0000) >> 16;
         int modG = (modColor & 0x00ff00) >> 8;
@@ -85,10 +85,10 @@ public abstract class BiomeWaterFogColors {
         int displayedB = (modB * legacyB) / 255;
         return (displayedR << 16) | (displayedG << 8) | displayedB;
     }
-    
+
     private static void processStringColor(String colorEntry) {
         String[] fields = colorEntry.split(",", -1);
-        if(fields.length != 3) {
+        if (fields.length != 3) {
             AquaAcrobatics.LOGGER.error("Incorrect syntax for '" + colorEntry + "'. Should be modname:biome,color,fogcolor (color and fogcolor may be empty)");
             return;
         }
@@ -97,47 +97,49 @@ public abstract class BiomeWaterFogColors {
             int mainColor = Integer.decode(fields[1]);
             baseColorMap.put(location, mainColor);
         } catch (NumberFormatException e) {
-            if(!baseColorMap.containsKey(location))
+            if (!baseColorMap.containsKey(location))
                 baseColorMap.put(location, DEFAULT_WATER_COLOR);
         }
         try {
             int fogColor = Integer.decode(fields[2]);
             fogColorMap.put(location, fogColor);
         } catch (NumberFormatException e) {
-            if(!fogColorMap.containsKey(location))
+            if (!fogColorMap.containsKey(location))
                 fogColorMap.put(location, DEFAULT_WATER_FOG_COLOR);
         }
     }
+
     public static void recomputeColors() {
         fogColorMap.clear();
         baseColorMap.clear();
-        for(String colorEntry : DEFAULT_COLORS) {
+        for (String colorEntry : DEFAULT_COLORS) {
             processStringColor(colorEntry);
         }
-        for(String colorEntry : ConfigHandler.MiscellaneousConfig.customBiomeWaterColors) {
+        for (String colorEntry : ConfigHandler.MiscellaneousConfig.customBiomeWaterColors) {
             processStringColor(colorEntry);
         }
     }
-    
+
     public static int getWaterFogColorForBiome(Biome biome) {
         ResourceLocation location = biome.getRegistryName();
-        if(location == null)
+        if (location == null)
             return DEFAULT_WATER_FOG_COLOR;
         Integer color = fogColorMap.get(location);
-        if(color != null)
+        if (color != null)
             return color;
         return DEFAULT_WATER_FOG_COLOR;
     }
+
     public static int getWaterColorForBiome(Biome biome, int oldColor) {
         ResourceLocation location = biome.getRegistryName();
-        if(location == null) {
+        if (location == null) {
             return DEFAULT_WATER_COLOR;
         }
         Integer color = baseColorMap.get(location);
-        if(color != null) {
+        if (color != null) {
             return color;
         }
-        if(oldColor != DEFAULT_WATER_COLOR_112) {
+        if (oldColor != DEFAULT_WATER_COLOR_112) {
             AquaAcrobatics.LOGGER.info("Potentially missing water color mapping for " + location + ", attempting to fake old appearance");
             color = emulateLegacyColor(oldColor);
         } else

--- a/src/main/java/com/fuzs/aquaacrobatics/block/BlockBubbleColumn.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/block/BlockBubbleColumn.java
@@ -32,124 +32,121 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class BlockBubbleColumn extends BlockStaticLiquid {
-   public static final PropertyBool DRAG = PropertyBool.create("drag"); /* true: upwards, false: downwards */
+    public static final PropertyBool DRAG = PropertyBool.create("drag"); /* true: upwards, false: downwards */
 
-   public BlockBubbleColumn() {
-      super(Material.WATER);
-      this.setRegistryName("bubble_column");
-      this.setTranslationKey("tile.aquaacrobatics.bubble.column.name");
-      this.setDefaultState(this.blockState.getBaseState().withProperty(LEVEL, 0).withProperty(DRAG, false));
-   }
+    public BlockBubbleColumn() {
+        super(Material.WATER);
+        this.setRegistryName("bubble_column");
+        this.setTranslationKey("tile.aquaacrobatics.bubble.column.name");
+        this.setDefaultState(this.blockState.getBaseState().withProperty(LEVEL, 0).withProperty(DRAG, false));
+    }
 
-   @Override
-   protected BlockStateContainer createBlockState()
-   {
-      BlockStateContainer.Builder builder = new BlockStateContainer.Builder(this).add(LEVEL, DRAG);
-      if(Loader.isModLoaded("fluidlogged_api"))
-         builder = builder.add(BlockFluidBase.FLUID_RENDER_PROPS.toArray(new IUnlistedProperty<?>[0]));
-      return builder.build();
-   }
-   
-
-   @Override
-   public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
-      IBlockState iblockstate = worldIn.getBlockState(pos.up());
-      IBubbleColumnInteractable bubbleEntity = (IBubbleColumnInteractable)entityIn;
-      boolean downwards = !state.getValue(DRAG);
-      if (iblockstate.getBlock() == Blocks.AIR) {
-         bubbleEntity.onEnterBubbleColumnWithAirAbove(downwards);
-      } else {
-         bubbleEntity.onEnterBubbleColumn(downwards);
-      }
-   }
-   
-   public static void placeBubbleColumn(World world, BlockPos pos, boolean isUpwards) {
-      if(!ConfigHandler.MiscellaneousConfig.bubbleColumns)
-         return;
-      if (canHoldBubbleColumn(world, pos)) {
-         world.setBlockState(pos, CommonProxy.BUBBLE_COLUMN.getDefaultState().withProperty(DRAG, isUpwards), Constants.BlockFlags.SEND_TO_CLIENTS);
-      }
-   }
-
-   public static boolean canHoldBubbleColumn(World world, BlockPos pos) {
-      if(world.provider.doesWaterVaporize())
-         return false;
-      IBlockState self = world.getBlockState(pos);
-      if(self.getMaterial() != Material.WATER)
-         return false;
-      if(!(self.getBlock() instanceof BlockLiquid))
-         return false;
-      if(self.getValue(LEVEL) != 0)
-         return false;
-      return true;
-   }
-
-   @SideOnly(Side.CLIENT)
-   public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
-      double d0 = pos.getX();
-      double d1 = pos.getY();
-      double d2 = pos.getZ();
-      Minecraft mc = Minecraft.getMinecraft();
-      if (!stateIn.getValue(DRAG)) {
-         mc.effectRenderer.addEffect(new ParticleCurrentDown(worldIn, d0 + 0.5D, d1 + 0.8D, d2));
-      } else {
-         mc.effectRenderer.addEffect(new ParticleBubbleColumnUp(worldIn, d0 + 0.5D, d1, d2 + 0.5D, 0.0D, 0.04D, 0.0D));
-         mc.effectRenderer.addEffect(new ParticleBubbleColumnUp(worldIn, d0 + (double)rand.nextFloat(), d1 + (double)rand.nextFloat(), d2 + (double)rand.nextFloat(), 0.0D, 0.04D, 0.0D));
-      }
-   }
-
-   public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
-      if (!this.isValidPosition(worldIn, pos)) {
-         worldIn.setBlockState(pos, Blocks.WATER.getDefaultState());
-         return;
-      }
-      if (fromPos.up().equals(pos)) {
-         worldIn.setBlockState(pos, CommonProxy.BUBBLE_COLUMN.getDefaultState().withProperty(DRAG, getDrag(worldIn, fromPos)), Constants.BlockFlags.SEND_TO_CLIENTS);
-      } else if (fromPos.down().equals(pos) && worldIn.getBlockState(fromPos).getBlock() != this && canHoldBubbleColumn(worldIn, fromPos)) {
-         worldIn.scheduleUpdate(pos, this, this.tickRate(worldIn));
-      }
-      if(fromPos.getX() != pos.getX() || fromPos.getZ() != pos.getZ())
-         super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
-   }
-
-   public boolean isValidPosition(World worldIn, BlockPos pos) {
-      Block block = worldIn.getBlockState(pos.down()).getBlock();
-      return block == this || block == (worldIn.getBlockState(pos).getValue(DRAG) ? Blocks.SOUL_SAND : Blocks.MAGMA);
-   }
-
-   private static boolean getDrag(IBlockAccess p_203157_0_, BlockPos p_203157_1_) {
-      IBlockState iblockstate = p_203157_0_.getBlockState(p_203157_1_);
-      Block block = iblockstate.getBlock();
-      if (block == CommonProxy.BUBBLE_COLUMN) {
-         return iblockstate.getValue(DRAG);
-      } else {
-         return block == Blocks.SOUL_SAND;
-      }
-   }
-
-   
-   public void onBlockAdded(World worldIn, BlockPos pos, IBlockState state) {
-      super.onBlockAdded(worldIn, pos, state);
-      placeBubbleColumn(worldIn, pos.up(), getDrag(worldIn, pos.down()));
-   }
-
-   public void updateTick(World worldIn, BlockPos pos, IBlockState state, Random rand) {
-      placeBubbleColumn(worldIn, pos.up(), getDrag(worldIn, pos));
-   }
+    @Override
+    protected BlockStateContainer createBlockState() {
+        BlockStateContainer.Builder builder = new BlockStateContainer.Builder(this).add(LEVEL, DRAG);
+        if (Loader.isModLoaded("fluidlogged_api"))
+            builder = builder.add(BlockFluidBase.FLUID_RENDER_PROPS.toArray(new IUnlistedProperty<?>[0]));
+        return builder.build();
+    }
 
 
-   public IBlockState getStateFromMeta(int meta)
-   {
-      return this.getDefaultState().withProperty(LEVEL, 0).withProperty(DRAG, (meta & 1) == 1);
-   }
+    @Override
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+        IBlockState iblockstate = worldIn.getBlockState(pos.up());
+        IBubbleColumnInteractable bubbleEntity = (IBubbleColumnInteractable) entityIn;
+        boolean downwards = !state.getValue(DRAG);
+        if (iblockstate.getBlock() == Blocks.AIR) {
+            bubbleEntity.onEnterBubbleColumnWithAirAbove(downwards);
+        } else {
+            bubbleEntity.onEnterBubbleColumn(downwards);
+        }
+    }
 
-   public int tickRate(World worldIn) {
-      return 5;
-   }
+    public static void placeBubbleColumn(World world, BlockPos pos, boolean isUpwards) {
+        if (!ConfigHandler.MiscellaneousConfig.bubbleColumns)
+            return;
+        if (canHoldBubbleColumn(world, pos)) {
+            world.setBlockState(pos, CommonProxy.BUBBLE_COLUMN.getDefaultState().withProperty(DRAG, isUpwards), Constants.BlockFlags.SEND_TO_CLIENTS);
+        }
+    }
+
+    public static boolean canHoldBubbleColumn(World world, BlockPos pos) {
+        if (world.provider.doesWaterVaporize())
+            return false;
+        IBlockState self = world.getBlockState(pos);
+        if (self.getMaterial() != Material.WATER)
+            return false;
+        if (!(self.getBlock() instanceof BlockLiquid))
+            return false;
+        if (self.getValue(LEVEL) != 0)
+            return false;
+        return true;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
+        double d0 = pos.getX();
+        double d1 = pos.getY();
+        double d2 = pos.getZ();
+        Minecraft mc = Minecraft.getMinecraft();
+        if (!stateIn.getValue(DRAG)) {
+            mc.effectRenderer.addEffect(new ParticleCurrentDown(worldIn, d0 + 0.5D, d1 + 0.8D, d2));
+        } else {
+            mc.effectRenderer.addEffect(new ParticleBubbleColumnUp(worldIn, d0 + 0.5D, d1, d2 + 0.5D, 0.0D, 0.04D, 0.0D));
+            mc.effectRenderer.addEffect(new ParticleBubbleColumnUp(worldIn, d0 + (double) rand.nextFloat(), d1 + (double) rand.nextFloat(), d2 + (double) rand.nextFloat(), 0.0D, 0.04D, 0.0D));
+        }
+    }
+
+    public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        if (!this.isValidPosition(worldIn, pos)) {
+            worldIn.setBlockState(pos, Blocks.WATER.getDefaultState());
+            return;
+        }
+        if (fromPos.up().equals(pos)) {
+            worldIn.setBlockState(pos, CommonProxy.BUBBLE_COLUMN.getDefaultState().withProperty(DRAG, getDrag(worldIn, fromPos)), Constants.BlockFlags.SEND_TO_CLIENTS);
+        } else if (fromPos.down().equals(pos) && worldIn.getBlockState(fromPos).getBlock() != this && canHoldBubbleColumn(worldIn, fromPos)) {
+            worldIn.scheduleUpdate(pos, this, this.tickRate(worldIn));
+        }
+        if (fromPos.getX() != pos.getX() || fromPos.getZ() != pos.getZ())
+            super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
+    }
+
+    public boolean isValidPosition(World worldIn, BlockPos pos) {
+        Block block = worldIn.getBlockState(pos.down()).getBlock();
+        return block == this || block == (worldIn.getBlockState(pos).getValue(DRAG) ? Blocks.SOUL_SAND : Blocks.MAGMA);
+    }
+
+    private static boolean getDrag(IBlockAccess p_203157_0_, BlockPos p_203157_1_) {
+        IBlockState iblockstate = p_203157_0_.getBlockState(p_203157_1_);
+        Block block = iblockstate.getBlock();
+        if (block == CommonProxy.BUBBLE_COLUMN) {
+            return iblockstate.getValue(DRAG);
+        } else {
+            return block == Blocks.SOUL_SAND;
+        }
+    }
 
 
-   public int getMetaFromState(IBlockState state)
-   {
-      return state.getValue(DRAG) ? 1 : 0;
-   }
+    public void onBlockAdded(World worldIn, BlockPos pos, IBlockState state) {
+        super.onBlockAdded(worldIn, pos, state);
+        placeBubbleColumn(worldIn, pos.up(), getDrag(worldIn, pos.down()));
+    }
+
+    public void updateTick(World worldIn, BlockPos pos, IBlockState state, Random rand) {
+        placeBubbleColumn(worldIn, pos.up(), getDrag(worldIn, pos));
+    }
+
+
+    public IBlockState getStateFromMeta(int meta) {
+        return this.getDefaultState().withProperty(LEVEL, 0).withProperty(DRAG, (meta & 1) == 1);
+    }
+
+    public int tickRate(World worldIn) {
+        return 5;
+    }
+
+
+    public int getMetaFromState(IBlockState state) {
+        return state.getValue(DRAG) ? 1 : 0;
+    }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/entity/IPlayerSPSwimming.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/entity/IPlayerSPSwimming.java
@@ -13,7 +13,7 @@ public interface IPlayerSPSwimming {
     boolean canSwim();
 
     boolean isMovingForward(float moveForward, float moveStrafe);
-    
+
     boolean canPerformElytraTakeoff();
 
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/gui/GuiNoMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/gui/GuiNoMixin.java
@@ -35,8 +35,7 @@ public class GuiNoMixin extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton button) {
 
-        switch (button.id)
-        {
+        switch (button.id) {
             case 1:
 
                 button.enabled = false;

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/AirMeterHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/AirMeterHandler.java
@@ -31,8 +31,8 @@ public class AirMeterHandler {
             int left = evt.getResolution().getScaledWidth() / 2 + 91;
             int top = evt.getResolution().getScaledHeight() - GuiIngameForge.right_height;
             int air = playerIn.getAir();
-            int full = MathHelper.ceil((double)(air - 2) * 10.0D / 300.0D);
-            int partial = MathHelper.ceil((double)air * 10.0D / 300.0D) - full;
+            int full = MathHelper.ceil((double) (air - 2) * 10.0D / 300.0D);
+            int partial = MathHelper.ceil((double) air * 10.0D / 300.0D) - full;
             for (int i = 0; i < full + partial; ++i) {
 
                 this.mc.ingameGUI.drawTexturedModalRect(left - i * 8 - 9, top, (i < full ? 16 : 25), 18, 9, 9);

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
@@ -35,7 +35,7 @@ import java.util.HashSet;
 
 /**
  * Uses Forge events to adjust water rendering so it more closely approximates 1.13+.
- *
+ * <p>
  * Some of the code in this class is based off of Minecraft 1.16.
  */
 public class FogHandler {
@@ -43,33 +43,31 @@ public class FogHandler {
     private int targetFogColor = -1;
     private int prevFogColor = -1;
     private long fogAdjustTime = -1L;
-    
+
     private static HashSet<String> worldProviderClassNames = null;
-    
+
     public static void recomputeBlacklist() {
         worldProviderClassNames = new HashSet<>();
         worldProviderClassNames.addAll(Arrays.asList(ConfigHandler.MiscellaneousConfig.providerFogBlacklist));
     }
-    
+
     private boolean shouldSkipFogOverride(World world) {
-        if(!ConfigHandler.BlocksConfig.newWaterFog)
+        if (!ConfigHandler.BlocksConfig.newWaterFog)
             return true;
         return worldProviderClassNames.contains(world.provider.getClass().getName());
     }
 
     @SubscribeEvent
-    public void registerBlockColors(ColorHandlerEvent.Block event){
-        if(ConfigHandler.MiscellaneousConfig.bubbleColumns)
-            event.getBlockColors().registerBlockColorHandler(new IBlockColor()
-            {
-                public int colorMultiplier(IBlockState state, @Nullable IBlockAccess worldIn, @Nullable BlockPos pos, int tintIndex)
-                {
+    public void registerBlockColors(ColorHandlerEvent.Block event) {
+        if (ConfigHandler.MiscellaneousConfig.bubbleColumns)
+            event.getBlockColors().registerBlockColorHandler(new IBlockColor() {
+                public int colorMultiplier(IBlockState state, @Nullable IBlockAccess worldIn, @Nullable BlockPos pos, int tintIndex) {
                     return worldIn != null && pos != null ? BiomeColorHelper.getWaterColorAtPos(worldIn, pos) : -1;
                 }
-    
+
             }, CommonProxy.BUBBLE_COLUMN);
     }
-    
+
     @SubscribeEvent
     public void onRenderFogDensity(EntityViewRenderEvent.FogDensity event) {
         switch (ConfigHandler.BlocksConfig.waterFogMode) {
@@ -84,14 +82,14 @@ public class FogHandler {
 
     private void handleExp2Fog(EntityViewRenderEvent.FogDensity event) {
         Entity eventEntity = event.getEntity();
-        if(eventEntity instanceof EntityLivingBase && ((EntityLivingBase)eventEntity).isPotionActive(MobEffects.BLINDNESS))
+        if (eventEntity instanceof EntityLivingBase && ((EntityLivingBase) eventEntity).isPotionActive(MobEffects.BLINDNESS))
             return;
-        if(event.getState().getMaterial() == Material.WATER && !shouldSkipFogOverride(eventEntity.getEntityWorld())) {
+        if (event.getState().getMaterial() == Material.WATER && !shouldSkipFogOverride(eventEntity.getEntityWorld())) {
             GlStateManager.setFog(GlStateManager.FogMode.EXP2);
             float density = 0.05f;
-            if(eventEntity instanceof EntityPlayer) {
-                EntityPlayer playerEntity = (EntityPlayer)eventEntity;
-                float waterVision = ((IPlayerResizeable)playerEntity).getWaterVision();
+            if (eventEntity instanceof EntityPlayer) {
+                EntityPlayer playerEntity = (EntityPlayer) eventEntity;
+                float waterVision = ((IPlayerResizeable) playerEntity).getWaterVision();
                 density -= waterVision * waterVision * 0.03F;
                 Biome biome = playerEntity.world.getBiome(playerEntity.getPosition());
                 if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SWAMP)) {
@@ -106,6 +104,7 @@ public class FogHandler {
     // Based on Minecraft 1.21.7
     static final float FOG_END = 96.0F;
     static final float FOG_START = -8.0F;
+
     private void handleLinearFog(EntityViewRenderEvent.FogDensity event) {
         Entity eventEntity = event.getEntity();
         if (eventEntity instanceof EntityLivingBase && ((EntityLivingBase) eventEntity).isPotionActive(MobEffects.BLINDNESS)) {
@@ -135,14 +134,13 @@ public class FogHandler {
     }
 
 
-
     /* LOW to override mods like Biomes O' Plenty which force their own underwater fog color */
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onRenderFogColor(EntityViewRenderEvent.FogColors event) {
-        if(!ConfigHandler.BlocksConfig.newWaterColors)
+        if (!ConfigHandler.BlocksConfig.newWaterColors)
             return;
         Block blockInside = event.getState().getBlock();
-        if((event.getState().getMaterial() == Material.WATER) && event.getEntity() instanceof EntityPlayer && !shouldSkipFogOverride(event.getEntity().getEntityWorld())) {
+        if ((event.getState().getMaterial() == Material.WATER) && event.getEntity() instanceof EntityPlayer && !shouldSkipFogOverride(event.getEntity().getEntityWorld())) {
             float fogRed, fogGreen, fogBlue;
             EntityPlayer playerEntity = (EntityPlayer) event.getEntity();
             long i = System.nanoTime() / 1000000L;
@@ -158,10 +156,10 @@ public class FogHandler {
             int j1 = prevFogColor >> 16 & 255;
             int k1 = prevFogColor >> 8 & 255;
             int l1 = prevFogColor & 255;
-            float f = MathHelper.clamp((float)(i - fogAdjustTime) / 5000.0F, 0.0F, 1.0F);
-            float f1 = MathHelperNew.lerp(f, (float)j1, (float)k);
-            float f2 = MathHelperNew.lerp(f, (float)k1, (float)l);
-            float f3 = MathHelperNew.lerp(f, (float)l1, (float)i1);
+            float f = MathHelper.clamp((float) (i - fogAdjustTime) / 5000.0F, 0.0F, 1.0F);
+            float f1 = MathHelperNew.lerp(f, (float) j1, (float) k);
+            float f2 = MathHelperNew.lerp(f, (float) k1, (float) l);
+            float f3 = MathHelperNew.lerp(f, (float) l1, (float) i1);
             fogRed = f1 / 255.0F;
             fogGreen = f2 / 255.0F;
             fogBlue = f3 / 255.0F;
@@ -170,7 +168,7 @@ public class FogHandler {
                 prevFogColor = MathHelper.floor(f1) << 16 | MathHelper.floor(f2) << 8 | MathHelper.floor(f3);
                 fogAdjustTime = i;
             }
-            float f6 = ((IPlayerResizeable)playerEntity).getWaterVision();
+            float f6 = ((IPlayerResizeable) playerEntity).getWaterVision();
             float f9 = Math.min(1.0F / fogRed, Math.min(1.0F / fogGreen, 1.0F / fogBlue));
             fogRed = fogRed * (1.0F - f6) + fogRed * f9 * f6;
             fogGreen = fogGreen * (1.0F - f6) + fogGreen * f9 * f6;
@@ -180,7 +178,7 @@ public class FogHandler {
             if (playerEntity.isPotionActive(MobEffects.BLINDNESS)) {
                 int potionDuration = playerEntity.getActivePotionEffect(MobEffects.BLINDNESS).getDuration();
                 if (potionDuration < 20) {
-                    blindnessFactor *= (1.0F - (float)potionDuration / 20.0F);
+                    blindnessFactor *= (1.0F - (float) potionDuration / 20.0F);
                 } else {
                     blindnessFactor = 0.0D;
                 }
@@ -192,15 +190,15 @@ public class FogHandler {
                 }
 
                 blindnessFactor = blindnessFactor * blindnessFactor;
-                fogRed = (float)((double)fogRed * blindnessFactor);
-                fogGreen = (float)((double)fogGreen * blindnessFactor);
-                fogBlue = (float)((double)fogBlue * blindnessFactor);
+                fogRed = (float) ((double) fogRed * blindnessFactor);
+                fogGreen = (float) ((double) fogGreen * blindnessFactor);
+                fogBlue = (float) ((double) fogBlue * blindnessFactor);
             }
 
             event.setRed(fogRed);
             event.setGreen(fogGreen);
             event.setBlue(fogBlue);
-        } else if((blockInside == Blocks.LAVA || blockInside == Blocks.FLOWING_LAVA)) {
+        } else if ((blockInside == Blocks.LAVA || blockInside == Blocks.FLOWING_LAVA)) {
             event.setRed(0.6f);
             event.setGreen(0.1f);
             event.setBlue(0.0f);

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
@@ -5,6 +5,7 @@ import com.fuzs.aquaacrobatics.config.ConfigHandler;
 import com.fuzs.aquaacrobatics.entity.player.IPlayerResizeable;
 import com.fuzs.aquaacrobatics.proxy.CommonProxy;
 import com.fuzs.aquaacrobatics.util.math.MathHelperNew;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.MobEffects;
@@ -102,16 +103,20 @@ public class FogHandler {
         }
     }
 
-    // Based on Minecraft 1.21.6
+    // Based on Minecraft 1.21.7
+    static final float FOG_END = 96.0F;
+    static final float FOG_START = -8.0F;
     private void handleLinearFog(EntityViewRenderEvent.FogDensity event) {
         Entity eventEntity = event.getEntity();
         if (eventEntity instanceof EntityLivingBase && ((EntityLivingBase) eventEntity).isPotionActive(MobEffects.BLINDNESS)) {
             return;
         }
+
         if (event.getState().getMaterial() == Material.WATER && !shouldSkipFogOverride(eventEntity.getEntityWorld())) {
             GlStateManager.setFog(GlStateManager.FogMode.LINEAR);
-            float fogStart = -8.0F;
-            float fogEnd = 96.0F;
+
+            float renderDistanceInBlocks = Minecraft.getMinecraft().gameSettings.renderDistanceChunks * 16.0f;
+            float fogEnd = Math.min(renderDistanceInBlocks, FOG_END);
 
             if (eventEntity instanceof EntityPlayer) {
                 EntityPlayer playerEntity = (EntityPlayer) eventEntity;
@@ -123,7 +128,7 @@ public class FogHandler {
                 }
             }
 
-            GlStateManager.setFogStart(fogStart);
+            GlStateManager.setFogStart(FOG_START);
             GlStateManager.setFogEnd(fogEnd);
             event.setCanceled(true);
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
@@ -180,7 +180,7 @@ public class FogHandler {
             if (playerEntity.isPotionActive(MobEffects.BLINDNESS)) {
                 int potionDuration = playerEntity.getActivePotionEffect(MobEffects.BLINDNESS).getDuration();
                 if (potionDuration < 20) {
-                    blindnessFactor *= (1.0F - (float)i / 20.0F);
+                    blindnessFactor *= (1.0F - (float)potionDuration / 20.0F);
                 } else {
                     blindnessFactor = 0.0D;
                 }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
@@ -118,7 +118,7 @@ public class FogHandler {
                 float waterVision = ((IPlayerResizeable) playerEntity).getWaterVision();
                 fogEnd *= Math.max(0.25F, waterVision);
                 Biome biome = playerEntity.world.getBiome(playerEntity.getPosition());
-                if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SWAMP) || BiomeDictionary.hasType(biome, BiomeDictionary.Type.WATER)) {
+                if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SWAMP)) {
                     fogEnd *= 0.85F;
                 }
             }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/FogHandler.java
@@ -71,6 +71,17 @@ public class FogHandler {
     
     @SubscribeEvent
     public void onRenderFogDensity(EntityViewRenderEvent.FogDensity event) {
+        switch (ConfigHandler.BlocksConfig.waterFogMode) {
+            case AA_EXP2:
+                handleExp2Fog(event);
+                break;
+            case VANILLA_LINEAR:
+                handleLinearFog(event);
+                break;
+        }
+    }
+
+    private void handleExp2Fog(EntityViewRenderEvent.FogDensity event) {
         Entity eventEntity = event.getEntity();
         if(eventEntity instanceof EntityLivingBase && ((EntityLivingBase)eventEntity).isPotionActive(MobEffects.BLINDNESS))
             return;
@@ -90,6 +101,35 @@ public class FogHandler {
             event.setCanceled(true);
         }
     }
+
+    // Based on Minecraft 1.21.6
+    private void handleLinearFog(EntityViewRenderEvent.FogDensity event) {
+        Entity eventEntity = event.getEntity();
+        if (eventEntity instanceof EntityLivingBase && ((EntityLivingBase) eventEntity).isPotionActive(MobEffects.BLINDNESS)) {
+            return;
+        }
+        if (event.getState().getMaterial() == Material.WATER && !shouldSkipFogOverride(eventEntity.getEntityWorld())) {
+            GlStateManager.setFog(GlStateManager.FogMode.LINEAR);
+            float fogStart = -8.0F;
+            float fogEnd = 96.0F;
+
+            if (eventEntity instanceof EntityPlayer) {
+                EntityPlayer playerEntity = (EntityPlayer) eventEntity;
+                float waterVision = ((IPlayerResizeable) playerEntity).getWaterVision();
+                fogEnd *= Math.max(0.25F, waterVision);
+                Biome biome = playerEntity.world.getBiome(playerEntity.getPosition());
+                if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SWAMP) || BiomeDictionary.hasType(biome, BiomeDictionary.Type.WATER)) {
+                    fogEnd *= 0.85F;
+                }
+            }
+
+            GlStateManager.setFogStart(fogStart);
+            GlStateManager.setFogEnd(fogEnd);
+            event.setCanceled(true);
+        }
+    }
+
+
 
     /* LOW to override mods like Biomes O' Plenty which force their own underwater fog color */
     @SubscribeEvent(priority = EventPriority.LOW)

--- a/src/main/java/com/fuzs/aquaacrobatics/client/handler/NoMixinHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/handler/NoMixinHandler.java
@@ -14,7 +14,7 @@ public class NoMixinHandler {
     public void onGuiOpen(final GuiOpenEvent evt) {
 
         if (evt.getGui() instanceof GuiMainMenu) {
-            if(!AquaAcrobaticsCore.isLoaded()) {
+            if (!AquaAcrobaticsCore.isLoaded()) {
                 evt.setGui(new GuiNoMixin(evt.getGui()));
             }
             MinecraftForge.EVENT_BUS.unregister(this);

--- a/src/main/java/com/fuzs/aquaacrobatics/client/model/WaterResourcePack.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/model/WaterResourcePack.java
@@ -25,7 +25,7 @@ public class WaterResourcePack extends AbstractResourcePack {
 
     @Override
     protected InputStream getInputStreamByName(String name) throws IOException {
-        if(name.equals("pack.mcmeta"))
+        if (name.equals("pack.mcmeta"))
             return AquaAcrobatics.class.getResourceAsStream("/water_pack.mcmeta");
         String truePath = "/" + name.replace("minecraft", "aquaacrobatics/overrides");
         return AquaAcrobatics.class.getResourceAsStream(truePath);

--- a/src/main/java/com/fuzs/aquaacrobatics/client/particle/ParticleBubbleColumnUp.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/particle/ParticleBubbleColumnUp.java
@@ -9,36 +9,36 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ParticleBubbleColumnUp extends Particle {
-   public ParticleBubbleColumnUp(World p_i48833_1_, double p_i48833_2_, double p_i48833_4_, double p_i48833_6_, double p_i48833_8_, double p_i48833_10_, double p_i48833_12_) {
-      super(p_i48833_1_, p_i48833_2_, p_i48833_4_, p_i48833_6_, p_i48833_8_, p_i48833_10_, p_i48833_12_);
-      this.particleRed = 1.0F;
-      this.particleGreen = 1.0F;
-      this.particleBlue = 1.0F;
-      this.setParticleTextureIndex(32);
-      this.setSize(0.02F, 0.02F);
-      this.particleScale *= this.rand.nextFloat() * 0.6F + 0.2F;
-      this.motionX = p_i48833_8_ * (double)0.2F + (Math.random() * 2.0D - 1.0D) * (double)0.02F;
-      this.motionY = p_i48833_10_ * (double)0.2F + (Math.random() * 2.0D - 1.0D) * (double)0.02F;
-      this.motionZ = p_i48833_12_ * (double)0.2F + (Math.random() * 2.0D - 1.0D) * (double)0.02F;
-      this.particleMaxAge = (int)(40.0D / (Math.random() * 0.8D + 0.2D));
-   }
+    public ParticleBubbleColumnUp(World p_i48833_1_, double p_i48833_2_, double p_i48833_4_, double p_i48833_6_, double p_i48833_8_, double p_i48833_10_, double p_i48833_12_) {
+        super(p_i48833_1_, p_i48833_2_, p_i48833_4_, p_i48833_6_, p_i48833_8_, p_i48833_10_, p_i48833_12_);
+        this.particleRed = 1.0F;
+        this.particleGreen = 1.0F;
+        this.particleBlue = 1.0F;
+        this.setParticleTextureIndex(32);
+        this.setSize(0.02F, 0.02F);
+        this.particleScale *= this.rand.nextFloat() * 0.6F + 0.2F;
+        this.motionX = p_i48833_8_ * (double) 0.2F + (Math.random() * 2.0D - 1.0D) * (double) 0.02F;
+        this.motionY = p_i48833_10_ * (double) 0.2F + (Math.random() * 2.0D - 1.0D) * (double) 0.02F;
+        this.motionZ = p_i48833_12_ * (double) 0.2F + (Math.random() * 2.0D - 1.0D) * (double) 0.02F;
+        this.particleMaxAge = (int) (40.0D / (Math.random() * 0.8D + 0.2D));
+    }
 
-   public void onUpdate() {
-      this.prevPosX = this.posX;
-      this.prevPosY = this.posY;
-      this.prevPosZ = this.posZ;
-      this.motionY += 0.005D;
-      this.move(this.motionX, this.motionY, this.motionZ);
-      this.motionX *= (double)0.85F;
-      this.motionY *= (double)0.85F;
-      this.motionZ *= (double)0.85F;
-      if (this.world.getBlockState(new BlockPos(this.posX, this.posY, this.posZ)).getMaterial() != Material.WATER) {
-         this.setExpired();
-      }
+    public void onUpdate() {
+        this.prevPosX = this.posX;
+        this.prevPosY = this.posY;
+        this.prevPosZ = this.posZ;
+        this.motionY += 0.005D;
+        this.move(this.motionX, this.motionY, this.motionZ);
+        this.motionX *= (double) 0.85F;
+        this.motionY *= (double) 0.85F;
+        this.motionZ *= (double) 0.85F;
+        if (this.world.getBlockState(new BlockPos(this.posX, this.posY, this.posZ)).getMaterial() != Material.WATER) {
+            this.setExpired();
+        }
 
-      if (this.particleMaxAge-- <= 0) {
-         this.setExpired();
-      }
+        if (this.particleMaxAge-- <= 0) {
+            this.setExpired();
+        }
 
-   }
+    }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/client/particle/ParticleCurrentDown.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/client/particle/ParticleCurrentDown.java
@@ -13,39 +13,39 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class ParticleCurrentDown extends Particle {
-   private float field_203083_a;
+    private float field_203083_a;
 
-   public ParticleCurrentDown(World p_i48830_1_, double p_i48830_2_, double p_i48830_4_, double p_i48830_6_) {
-      super(p_i48830_1_, p_i48830_2_, p_i48830_4_, p_i48830_6_, 0.0D, 0.0D, 0.0D);
-      this.setParticleTextureIndex(32);
-      this.particleMaxAge = (int)(Math.random() * 60.0D) + 30;
-      this.canCollide = false;
-      this.motionX = 0.0D;
-      this.motionY = -0.05D;
-      this.motionZ = 0.0D;
-      this.setSize(0.02F, 0.02F);
-      this.particleScale *= this.rand.nextFloat() * 0.6F + 0.2F;
-      this.particleGravity = 0.002F;
-   }
+    public ParticleCurrentDown(World p_i48830_1_, double p_i48830_2_, double p_i48830_4_, double p_i48830_6_) {
+        super(p_i48830_1_, p_i48830_2_, p_i48830_4_, p_i48830_6_, 0.0D, 0.0D, 0.0D);
+        this.setParticleTextureIndex(32);
+        this.particleMaxAge = (int) (Math.random() * 60.0D) + 30;
+        this.canCollide = false;
+        this.motionX = 0.0D;
+        this.motionY = -0.05D;
+        this.motionZ = 0.0D;
+        this.setSize(0.02F, 0.02F);
+        this.particleScale *= this.rand.nextFloat() * 0.6F + 0.2F;
+        this.particleGravity = 0.002F;
+    }
 
-   public void onUpdate() {
-      this.prevPosX = this.posX;
-      this.prevPosY = this.posY;
-      this.prevPosZ = this.posZ;
-      float f = 0.6F;
-      this.motionX += (double)(0.6F * MathHelper.cos(this.field_203083_a));
-      this.motionZ += (double)(0.6F * MathHelper.sin(this.field_203083_a));
-      this.motionX *= 0.07D;
-      this.motionZ *= 0.07D;
-      this.move(this.motionX, this.motionY, this.motionZ);
-      if (this.world.getBlockState(new BlockPos(this.posX, this.posY, this.posZ)).getMaterial() != Material.WATER) {
-         this.setExpired();
-      }
+    public void onUpdate() {
+        this.prevPosX = this.posX;
+        this.prevPosY = this.posY;
+        this.prevPosZ = this.posZ;
+        float f = 0.6F;
+        this.motionX += (double) (0.6F * MathHelper.cos(this.field_203083_a));
+        this.motionZ += (double) (0.6F * MathHelper.sin(this.field_203083_a));
+        this.motionX *= 0.07D;
+        this.motionZ *= 0.07D;
+        this.move(this.motionX, this.motionY, this.motionZ);
+        if (this.world.getBlockState(new BlockPos(this.posX, this.posY, this.posZ)).getMaterial() != Material.WATER) {
+            this.setExpired();
+        }
 
-      if (this.particleAge++ >= this.particleMaxAge || this.onGround) {
-         this.setExpired();
-      }
+        if (this.particleAge++ >= this.particleMaxAge || this.onGround) {
+            this.setExpired();
+        }
 
-      this.field_203083_a = (float)((double)this.field_203083_a + 0.08D);
-   }
+        this.field_203083_a = (float) ((double) this.field_203083_a + 0.08D);
+    }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
@@ -194,9 +194,7 @@ public class ConfigHandler {
     @SuppressWarnings("unused")
     @SubscribeEvent
     public static void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent evt) {
-
         if (evt.getModID().equals(AquaAcrobatics.MODID)) {
-
             ConfigManager.sync(AquaAcrobatics.MODID, Config.Type.INSTANCE);
         }
         BiomeWaterFogColors.recomputeColors();

--- a/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
@@ -21,7 +21,7 @@ public class ConfigHandler {
     @Config.Name("blocks")
     @Config.Comment("Block-related config options (must match server).")
     public static BlocksConfig blocksConfig;
-    
+
     @SuppressWarnings("unused")
     @Config.Name("movement")
     @Config.Comment("Movement related config options.")
@@ -108,18 +108,18 @@ public class ConfigHandler {
         @Config.Name("Eating Animation")
         @Config.Comment("Animate eating in third-person view.")
         public static boolean eatingAnimation = true;
-        
+
         @Config.Name("Bubble Columns")
         @Config.Comment("Enable bubble columns.")
         public static boolean bubbleColumns = false;
 
         @Config.Name("Custom Biome Water Colors")
         @Config.Comment("Allows overriding the water and fog colors for a biome. Specify each entry like this (without quotes) - 'modname:biome,color,fogcolor'")
-        public static String[] customBiomeWaterColors = new String[] {};
+        public static String[] customBiomeWaterColors = new String[]{};
 
         @Config.Name("WorldProvider Fog Blacklist")
         @Config.Comment("List of WorldProviders in which fog should be disabled.")
-        public static String[] providerFogBlacklist = new String[] { "thebetweenlands.common.world.WorldProviderBetweenlands" };
+        public static String[] providerFogBlacklist = new String[]{"thebetweenlands.common.world.WorldProviderBetweenlands"};
 
         @Config.Name("Floating Items")
         @Config.Comment("Whether or not items should float in water like in 1.13+.")
@@ -149,7 +149,7 @@ public class ConfigHandler {
         @Config.Comment(COMPAT_DESCRIPTION)
         @Config.RequiresMcRestart
         public static boolean enderIoIntegration = true;
-        
+
         @Config.Name("Random Patches Integration")
         @Config.Comment(COMPAT_DESCRIPTION)
         public static boolean randomPatchesIntegration = true;

--- a/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/config/ConfigHandler.java
@@ -89,6 +89,10 @@ public class ConfigHandler {
         @Config.Name("New Water Fog")
         @Config.Comment("Use the new fog rendering in 1.13+.")
         public static boolean newWaterFog = true;
+
+        @Config.Name("New Water Fog Render Mode")
+        @Config.Comment("Water fog render mode, available options: AA_EXP2, VANILLA_LINEAR")
+        public static WaterFogMode waterFogMode = WaterFogMode.AA_EXP2;
     }
 
     public static class MiscellaneousConfig {
@@ -203,6 +207,10 @@ public class ConfigHandler {
     public enum PlayerBlockCollisions {
 
         STANDARD, APPROXIMATE, EXACT
+    }
+
+    public enum WaterFogMode {
+        AA_EXP2, VANILLA_LINEAR
     }
 
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsCore.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsCore.java
@@ -35,11 +35,11 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
     public static boolean isModCompatLoaded;
     public static boolean isFgDev;
     private static boolean isScreenRegistered;
-    
+
     /* Config options */
     public static boolean disableBlockUpdateMixins;
     public static boolean enableSkyBoxHeightOverwrite;
-    
+
     public AquaAcrobaticsCore() {
         SELF = this;
         Configuration config = new Configuration(new File("config", "aquaacrobatics_core.cfg"));
@@ -47,23 +47,23 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
         disableBlockUpdateMixins = config.getBoolean("DisableBlockUpdateMixins", "hacks", false, "TickCentral has a buggy ASM transformer - this will disable these mixins from being applied. Make sure bubble columns are disabled if you use this.");
         enableSkyBoxHeightOverwrite = config.getBoolean("EnableSkyBoxHeightOverwrite", "hacks", false, "Enable overwriting skybox renderer height, vanilla one may cause weird black edges near the chunk border.");
         config.save();
-        
+
         isFgDev = "true".equals(System.getProperty("aquaacrobatics.fghack"));
-        if(isFgDev)
+        if (isFgDev)
             setupMixins();
     }
-    
+
     static void setupMixins() {
         try {
             Class.forName("org.spongepowered.asm.launch.MixinTweaker");
-        } catch(ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             AquaAcrobaticsCore.LOGGER.error("No instance of Mixin framework detected. Unable to proceed load.", e);
             return;
         }
         MixinBootstrap.init();
         Mixins.addConfiguration("META-INF/mixins." + AquaAcrobaticsCore.MODID + ".json");
         isLoaded = true;
-        if(isFgDev) {
+        if (isFgDev) {
             AquaAcrobaticsCore.LOGGER.info("Running in userdev, proceeding to apply workaround to ensure mod is loaded");
             CodeSource codeSource = SELF.getClass().getProtectionDomain().getCodeSource();
             if (codeSource != null) {
@@ -73,7 +73,8 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
                     if (file.isFile()) {
                         CoreModManager.getReparseableCoremods().remove(file.getName());
                     }
-                } catch (URISyntaxException ignored) {}
+                } catch (URISyntaxException ignored) {
+                }
             } else {
                 AquaAcrobaticsCore.LOGGER.warn("No CodeSource, if this is not a development environment we might run into problems!");
                 AquaAcrobaticsCore.LOGGER.warn(SELF.getClass().getProtectionDomain());
@@ -82,7 +83,7 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
             AquaAcrobaticsCore.LOGGER.info("Running in obf, thanks for playing with the mod!");
         }
     }
-    
+
     @Override
     public String[] getASMTransformerClass() {
 
@@ -105,7 +106,7 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
     public void injectData(Map<String, Object> data) {
     }
 
-    
+
     @Override
     public String getAccessTransformerClass() {
 
@@ -117,9 +118,9 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
         if (!isScreenRegistered) {
 
             isScreenRegistered = true;
-            if(FMLCommonHandler.instance().getSide() == Side.CLIENT)
+            if (FMLCommonHandler.instance().getSide() == Side.CLIENT)
                 MinecraftForge.EVENT_BUS.register(new NoMixinHandler());
-            else if(!isLoaded) {
+            else if (!isLoaded) {
                 throw new RuntimeException("Mixin framework is missing, please install it.");
             }
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsCore.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsCore.java
@@ -2,7 +2,6 @@ package com.fuzs.aquaacrobatics.core;
 
 import com.fuzs.aquaacrobatics.AquaAcrobatics;
 import com.fuzs.aquaacrobatics.client.handler.NoMixinHandler;
-import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -38,13 +37,15 @@ public class AquaAcrobaticsCore implements IFMLLoadingPlugin {
     private static boolean isScreenRegistered;
     
     /* Config options */
-    public static boolean disableBlockUpdateMixins; 
+    public static boolean disableBlockUpdateMixins;
+    public static boolean enableSkyBoxHeightOverwrite;
     
     public AquaAcrobaticsCore() {
         SELF = this;
         Configuration config = new Configuration(new File("config", "aquaacrobatics_core.cfg"));
         config.load();
         disableBlockUpdateMixins = config.getBoolean("DisableBlockUpdateMixins", "hacks", false, "TickCentral has a buggy ASM transformer - this will disable these mixins from being applied. Make sure bubble columns are disabled if you use this.");
+        enableSkyBoxHeightOverwrite = config.getBoolean("EnableSkyBoxHeightOverwrite", "hacks", false, "Enable overwriting skybox renderer height, vanilla one may cause weird black edges near the chunk border.");
         config.save();
         
         isFgDev = "true".equals(System.getProperty("aquaacrobatics.fghack"));

--- a/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsMixinPlugin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsMixinPlugin.java
@@ -10,14 +10,14 @@ import java.util.Set;
 public class AquaAcrobaticsMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
-        
+
     }
 
     @Override
     public String getRefMapperConfig() {
         return null;
     }
-    
+
     private boolean doesClassExist(String name) {
         try {
             Class.forName(name);
@@ -29,8 +29,8 @@ public class AquaAcrobaticsMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if(AquaAcrobaticsCore.disableBlockUpdateMixins) {
-            if(mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.BlockSoulSandMixin") || mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.BlockMagmaMixin")) {
+        if (AquaAcrobaticsCore.disableBlockUpdateMixins) {
+            if (mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.BlockSoulSandMixin") || mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.BlockMagmaMixin")) {
                 AquaAcrobaticsCore.LOGGER.error("Disabling soul sand and magma mixins as requested in config.");
                 return false;
             }
@@ -44,7 +44,7 @@ public class AquaAcrobaticsMixinPlugin implements IMixinConfigPlugin {
             return true;
         }
 
-        if(mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.client.BlockAliasesBubbleColumnMixin")) {
+        if (mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.client.BlockAliasesBubbleColumnMixin")) {
             return doesClassExist("optifine.OptiFineForgeTweaker");
         }
 

--- a/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsMixinPlugin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsMixinPlugin.java
@@ -36,6 +36,14 @@ public class AquaAcrobaticsMixinPlugin implements IMixinConfigPlugin {
             }
         }
 
+        if (mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.client.RenderGlobalMixin")) {
+            if (!AquaAcrobaticsCore.enableSkyBoxHeightOverwrite) {
+                return false;
+            }
+            AquaAcrobaticsCore.LOGGER.error("Overwriting vanilla skybox height as requested in config.");
+            return true;
+        }
+
         if(mixinClassName.equals("com.fuzs.aquaacrobatics.core.mixin.client.BlockAliasesBubbleColumnMixin")) {
             return doesClassExist("optifine.OptiFineForgeTweaker");
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsSetupHook.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/AquaAcrobaticsSetupHook.java
@@ -13,7 +13,7 @@ public class AquaAcrobaticsSetupHook implements IFMLCallHook {
 
     @Override
     public Void call() {
-        if(!AquaAcrobaticsCore.isFgDev)
+        if (!AquaAcrobaticsCore.isFgDev)
             AquaAcrobaticsCore.setupMixins();
         return null;
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/ModCompatMixinHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/ModCompatMixinHandler.java
@@ -10,26 +10,26 @@ import zone.rong.mixinbooter.MixinLoader;
 public class ModCompatMixinHandler {
     public ModCompatMixinHandler() {
         AquaAcrobaticsCore.LOGGER.info("Aqua Acrobatics is loading mod compatibility mixins");
-        if(Loader.isModLoaded("galacticraftcore")) {
+        if (Loader.isModLoaded("galacticraftcore")) {
             Mixins.addConfiguration("META-INF/mixins.aquaacrobatics.galacticraft.json");
         }
-        if(Loader.isModLoaded("journeymap")) {
+        if (Loader.isModLoaded("journeymap")) {
             ModContainer jmMod = FMLCommonHandler.instance().findContainerFor("journeymap");
-            if(jmMod != null) {
+            if (jmMod != null) {
                 String version = jmMod.getVersion();
-                if(version.equals("1.12.2-5.5.4")) {
+                if (version.equals("1.12.2-5.5.4")) {
                     Mixins.addConfiguration("META-INF/mixins.aquaacrobatics.journeymap55.json");
-                } else if(version.equals("1.12.2-5.7.1")) {
+                } else if (version.equals("1.12.2-5.7.1")) {
                     Mixins.addConfiguration("META-INF/mixins.aquaacrobatics.journeymap57.json");
                 } else {
                     AquaAcrobaticsCore.LOGGER.warn("You have JourneyMap " + version + " installed. Only 1.12.2-5.5.4 and 1.12.2-5.7.1 are patched for water color compatibility.");
                 }
             }
         }
-        if(Loader.isModLoaded("xaerominimap")) {
+        if (Loader.isModLoaded("xaerominimap")) {
             Mixins.addConfiguration("META-INF/mixins.aquaacrobatics.xaerosminimap.json");
         }
-        if(Loader.isModLoaded("thaumcraft")) {
+        if (Loader.isModLoaded("thaumcraft")) {
             Mixins.addConfiguration("META-INF/mixins.aquaacrobatics.thaumcraft.json");
         }
         AquaAcrobaticsCore.isModCompatLoaded = true;

--- a/src/main/java/com/fuzs/aquaacrobatics/core/UnderwaterGrassLikeHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/UnderwaterGrassLikeHandler.java
@@ -11,12 +11,12 @@ import java.util.Random;
 
 public class UnderwaterGrassLikeHandler {
     public static void handleUnderwaterGrassLikeBlock(World world, BlockPos pos, IBlockState state, Random rand, CallbackInfo ci) {
-        if(world.isRemote || !world.isAreaLoaded(pos, 3)) {
+        if (world.isRemote || !world.isAreaLoaded(pos, 3)) {
             ci.cancel();
             return;
         }
         IBlockState above = world.getBlockState(pos.up());
-        if(above.getMaterial().isLiquid()) {
+        if (above.getMaterial().isLiquid()) {
             world.setBlockState(pos, Blocks.DIRT.getDefaultState());
             ci.cancel();
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
@@ -22,7 +22,7 @@ public abstract class GCEntityClientPlayerMPMixin extends EntityPlayerSP {
     public GCEntityClientPlayerMPMixin(Minecraft p_i47378_1_, World p_i47378_2_, NetHandlerPlayClient p_i47378_3_, StatisticsManager p_i47378_4_, RecipeBook p_i47378_5_) {
         super(p_i47378_1_, p_i47378_2_, p_i47378_3_, p_i47378_4_, p_i47378_5_);
     }
-    
+
     /**
      * @author embeddedt
      * Reason: use our logic for crouching.
@@ -32,7 +32,7 @@ public abstract class GCEntityClientPlayerMPMixin extends EntityPlayerSP {
         if (this.isPlayerSleeping()) {
             return 0.2f;
         }
-        IPlayerResizeable player = ((IPlayerResizeable)this);
+        IPlayerResizeable player = ((IPlayerResizeable) this);
         return player.getStandingEyeHeight(player.getPose(), player.getSize(player.getPose()));
         /*
         if (this.isPlayerSleeping()) {

--- a/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
@@ -25,7 +25,7 @@ public abstract class GCEntityClientPlayerMPMixin extends EntityPlayerSP {
 
     /**
      * @author embeddedt
-     * Reason: use our logic for crouching.
+     * @reason use our logic for crouching
      */
     @Overwrite
     public float getEyeHeight() {

--- a/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/galacticraft/mixin/GCEntityClientPlayerMPMixin.java
@@ -25,6 +25,7 @@ public abstract class GCEntityClientPlayerMPMixin extends EntityPlayerSP {
     
     /**
      * @author embeddedt
+     * Reason: use our logic for crouching.
      */
     @Overwrite
     public float getEyeHeight() {

--- a/src/main/java/com/fuzs/aquaacrobatics/core/journeymap55/mixin/client/VanillaBlockSpriteProxyMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/journeymap55/mixin/client/VanillaBlockSpriteProxyMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.common.Loader;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,6 +22,7 @@ import java.util.Collections;
 
 @Mixin(VanillaBlockSpriteProxy.class)
 public class VanillaBlockSpriteProxyMixin {
+    @Dynamic("journeymap")
     @Inject(
             method = "getSprites(Ljourneymap/client/model/BlockMD;)Ljava/util/Collection;",
             at = @At("HEAD"),

--- a/src/main/java/com/fuzs/aquaacrobatics/core/journeymap55/mixin/client/VanillaBlockSpriteProxyMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/journeymap55/mixin/client/VanillaBlockSpriteProxyMixin.java
@@ -32,7 +32,7 @@ public class VanillaBlockSpriteProxyMixin {
     )
     private void getSprites(BlockMD blockMD, CallbackInfoReturnable<Collection<ColoredSprite>> cir) {
         Block block = blockMD.getBlockState().getBlock();
-        if(ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER) && !Loader.isModLoaded("fluidlogged_api")) {
+        if (ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER) && !Loader.isModLoaded("fluidlogged_api")) {
             TextureAtlasSprite tas = FMLClientHandler.instance().getClient().getTextureMapBlocks().getAtlasSprite("aquaacrobatics:blocks/water_still");
             cir.setReturnValue(Collections.singletonList(new ColoredSprite(tas, null)));
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/journeymap57/mixin/client/VanillaBlockSpriteProxyMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/journeymap57/mixin/client/VanillaBlockSpriteProxyMixin.java
@@ -30,7 +30,7 @@ public class VanillaBlockSpriteProxyMixin {
     )
     private void getSprites(BlockMD blockMD, ChunkMD facing, BlockPos state, CallbackInfoReturnable<Collection<ColoredSprite>> cir) {
         Block block = blockMD.getBlockState().getBlock();
-        if(ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER) && !Loader.isModLoaded("fluidlogged_api")) {
+        if (ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER) && !Loader.isModLoaded("fluidlogged_api")) {
             TextureAtlasSprite tas = FMLClientHandler.instance().getClient().getTextureMapBlocks().getAtlasSprite("aquaacrobatics:blocks/water_still");
             cir.setReturnValue(Collections.singletonList(new ColoredSprite(tas, null)));
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeColorHelperMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeColorHelperMixin.java
@@ -6,10 +6,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
 import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Pseudo
 @Mixin(targets = { "net/minecraft/world/biome/BiomeColorHelper$3" })
 public class BiomeColorHelperMixin {
     /**

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeColorHelperMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeColorHelperMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
-@Mixin(targets = { "net/minecraft/world/biome/BiomeColorHelper$3" })
+@Mixin(targets = {"net/minecraft/world/biome/BiomeColorHelper$3"})
 public class BiomeColorHelperMixin {
     /**
      * Typically we would just use the GetWaterColor event... but mods like Thaumcraft don't call it
@@ -21,7 +21,7 @@ public class BiomeColorHelperMixin {
     @Inject(method = "func_180283_a", at = @At("RETURN"), cancellable = true, remap = false)
     @Dynamic("Exists only in an SRG environment")
     private void getNewWaterColorMultiplier(Biome biome, BlockPos position, CallbackInfoReturnable<Integer> cir) {
-        if(ConfigHandler.BlocksConfig.newWaterColors)
+        if (ConfigHandler.BlocksConfig.newWaterColors)
             cir.setReturnValue(BiomeWaterFogColors.getWaterColorForBiome(biome, cir.getReturnValue()));
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeMixin.java
@@ -11,12 +11,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Biome.class)
 public abstract class BiomeMixin {
-    @Shadow(remap = false) public abstract int getWaterColorMultiplier();
+    @Shadow(remap = false)
+    public abstract int getWaterColorMultiplier();
 
     /* For OptiFine */
     @SuppressWarnings("unused")
     public int aqua$waterColorMultiplier() {
-        if(ConfigHandler.BlocksConfig.newWaterColors) {
+        if (ConfigHandler.BlocksConfig.newWaterColors) {
             /* We might call getWaterColorForBiome twice, but it's fine because it caches after the first call */
             return BiomeWaterFogColors.getWaterColorForBiome((Biome) (Object) this, getWaterColorMultiplier());
         } else
@@ -25,8 +26,8 @@ public abstract class BiomeMixin {
 
     @Inject(method = "getWaterColorMultiplier", at = @At("TAIL"), remap = false, cancellable = true)
     private void forceNewColor(CallbackInfoReturnable<Integer> cir) {
-        if(ConfigHandler.BlocksConfig.newWaterColors) {
-            cir.setReturnValue(BiomeWaterFogColors.getWaterColorForBiome((Biome)(Object)this, cir.getReturnValue()));
+        if (ConfigHandler.BlocksConfig.newWaterColors) {
+            cir.setReturnValue(BiomeWaterFogColors.getWaterColorForBiome((Biome) (Object) this, cir.getReturnValue()));
         }
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BiomeMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Biome.class)
 public abstract class BiomeMixin {
-    @Shadow public abstract int getWaterColorMultiplier();
+    @Shadow(remap = false) public abstract int getWaterColorMultiplier();
 
     /* For OptiFine */
     @SuppressWarnings("unused")

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockGrassMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockGrassMixin.java
@@ -21,10 +21,10 @@ public abstract class BlockGrassMixin {
     private void updateUnderwaterToDirt(World world, BlockPos pos, IBlockState state, Random rand, CallbackInfo ci) {
         UnderwaterGrassLikeHandler.handleUnderwaterGrassLikeBlock(world, pos, state, rand, ci);
     }
-    
+
     @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z", ordinal = 1), require = 0)
     public boolean avoidSettingGrass(World world, BlockPos pos, IBlockState state) {
-        if(world.getBlockState(pos.up()).getMaterial().isLiquid())
+        if (world.getBlockState(pos.up()).getMaterial().isLiquid())
             return false;
         return world.setBlockState(pos, state);
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockLiquidMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockLiquidMixin.java
@@ -16,7 +16,7 @@ public abstract class BlockLiquidMixin extends Block {
     @Override
     @SuppressWarnings("deprecation")
     public int getLightOpacity(IBlockState state) {
-        if(ConfigHandler.BlocksConfig.brighterWater && state.getMaterial() == Material.WATER)
+        if (ConfigHandler.BlocksConfig.brighterWater && state.getMaterial() == Material.WATER)
             return 1;
         else
             return super.getLightOpacity(state);

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockMagmaMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockMagmaMixin.java
@@ -21,7 +21,7 @@ public abstract class BlockMagmaMixin extends Block {
     @Override
     @SuppressWarnings("deprecation")
     public void neighborChanged(IBlockState state, World worldIn, BlockPos thisPos, Block blockIn, BlockPos fromPos) {
-        if(worldIn.getBlockState(thisPos.up()).getMaterial() == Material.WATER) {
+        if (worldIn.getBlockState(thisPos.up()).getMaterial() == Material.WATER) {
             worldIn.scheduleUpdate(thisPos, this, this.tickRate(worldIn));
         }
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockMyceliumMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockMyceliumMixin.java
@@ -24,7 +24,7 @@ public abstract class BlockMyceliumMixin {
 
     @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z", ordinal = 1), require = 0)
     public boolean avoidSettingGrass(World world, BlockPos pos, IBlockState state) {
-        if(world.getBlockState(pos.up()).getMaterial().isLiquid())
+        if (world.getBlockState(pos.up()).getMaterial().isLiquid())
             return false;
         return world.setBlockState(pos, state);
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockSoulSandMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/BlockSoulSandMixin.java
@@ -33,7 +33,7 @@ public abstract class BlockSoulSandMixin extends Block {
     public int tickRate(World worldIn) {
         return 20;
     }
-    
+
     @Override
     public void updateTick(World worldIn, BlockPos pos, IBlockState state, Random rand) {
         BlockBubbleColumn.placeBubbleColumn(worldIn, pos.up(), true);

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityBoatMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityBoatMixin.java
@@ -27,11 +27,11 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
     private float rockingIntensity;
     private float rockingAngle;
     private float prevRockingAngle;
-    
+
     public EntityBoatMixin(World worldIn) {
         super(worldIn);
     }
-    
+
     public void onEnterBubbleColumnWithAirAbove(boolean downwards) {
         if (!world.isRemote) {
             this.aqua$rocking = true;
@@ -41,7 +41,7 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
             }
         }
 
-        this.world.spawnParticle(EnumParticleTypes.WATER_SPLASH, this.posX + (double)this.rand.nextFloat(), this.posY + 0.7D, this.posZ + (double)this.rand.nextFloat(), 0.0D, 0.0D, 0.0D);
+        this.world.spawnParticle(EnumParticleTypes.WATER_SPLASH, this.posX + (double) this.rand.nextFloat(), this.posY + 0.7D, this.posZ + (double) this.rand.nextFloat(), 0.0D, 0.0D, 0.0D);
         if (this.rand.nextInt(20) == 0) {
             this.world.playSound(this.posX, this.posY, this.posZ, this.getSplashSound(), this.getSoundCategory(), 1.0F, 0.8F + 0.4F * this.rand.nextFloat(), false);
         }
@@ -51,7 +51,7 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
     public void aqua$doRegisterData() {
         this.dataManager.register(BOAT_ROCKING_TICKS, 0);
     }
-    
+
     @Inject(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityBoat;doBlockCollisions()V"))
     private void updateRocking(CallbackInfo ci) {
         if (this.world.isRemote) {
@@ -64,7 +64,7 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
 
             this.rockingIntensity = MathHelper.clamp(this.rockingIntensity, 0.0F, 1.0F);
             this.prevRockingAngle = this.rockingAngle;
-            this.rockingAngle = 10.0F * (float)Math.sin((double)(0.5F * (float)this.world.getTotalWorldTime())) * this.rockingIntensity;
+            this.rockingAngle = 10.0F * (float) Math.sin((double) (0.5F * (float) this.world.getTotalWorldTime())) * this.rockingIntensity;
         } else {
             if (!this.aqua$rocking) {
                 this.setRockingTicks(0);
@@ -90,9 +90,9 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
         }
 
     }
-    
+
     private boolean aqua$isPlayerRiding() {
-        for(Entity entity : this.getPassengers()) {
+        for (Entity entity : this.getPassengers()) {
             if (EntityPlayer.class.isAssignableFrom(entity.getClass())) {
                 return true;
             }
@@ -102,20 +102,20 @@ public abstract class EntityBoatMixin extends Entity implements IBubbleColumnInt
     }
 
     public void setRockingTicks(int p_203055_1_) {
-        if(!ConfigHandler.MiscellaneousConfig.bubbleColumns)
+        if (!ConfigHandler.MiscellaneousConfig.bubbleColumns)
             return;
         this.dataManager.set(BOAT_ROCKING_TICKS, p_203055_1_);
     }
 
     public int getRockingTicks() {
-        if(!ConfigHandler.MiscellaneousConfig.bubbleColumns)
+        if (!ConfigHandler.MiscellaneousConfig.bubbleColumns)
             return 0;
         return this.dataManager.get(BOAT_ROCKING_TICKS);
     }
 
     @SideOnly(Side.CLIENT)
     public float getRockingAngle(float partialTicks) {
-        if(!ConfigHandler.MiscellaneousConfig.bubbleColumns)
+        if (!ConfigHandler.MiscellaneousConfig.bubbleColumns)
             return 0.0f;
         return this.prevRockingAngle + (this.rockingAngle - this.prevRockingAngle) * partialTicks;
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityItemMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityItemMixin.java
@@ -23,39 +23,40 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(EntityItem.class)
 public abstract class EntityItemMixin extends Entity {
-    @Shadow public abstract ItemStack getItem();
+    @Shadow
+    public abstract ItemStack getItem();
 
     public EntityItemMixin(World p_i1582_1_) {
         super(p_i1582_1_);
     }
 
     private void applyFloatMotion() {
-        if (this.motionY < (double)0.06F) {
-            this.motionY += (double)5.0E-4F;
+        if (this.motionY < (double) 0.06F) {
+            this.motionY += (double) 5.0E-4F;
         }
         this.motionX *= 0.99F;
         this.motionZ *= 0.99F;
     }
 
     private boolean aqua$shouldBeBuoyant() {
-        if(!ConfigHandler.MiscellaneousConfig.floatingItems)
+        if (!ConfigHandler.MiscellaneousConfig.floatingItems)
             return false;
-        if(IntegrationManager.isAE2Enabled() && AE2Integration.isGrowingCrystal((EntityItem)(Object)this))
+        if (IntegrationManager.isAE2Enabled() && AE2Integration.isGrowingCrystal((EntityItem) (Object) this))
             return false;
         return true;
     }
-    
-    @Redirect(method = "onUpdate", at = @At(value="INVOKE", target = "Lnet/minecraft/entity/item/EntityItem;hasNoGravity()Z", ordinal = 0), expect = 1, require = 0)
+
+    @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityItem;hasNoGravity()Z", ordinal = 0), expect = 1, require = 0)
     private boolean applyFloatMotionIfInWater(EntityItem entityItem) {
-        if(!aqua$shouldBeBuoyant()) {
+        if (!aqua$shouldBeBuoyant()) {
             return false;
         }
-        double eyePosition = this.posY + (double)this.getEyeHeight();
+        double eyePosition = this.posY + (double) this.getEyeHeight();
         BlockPos eyeBlockPos = new BlockPos(this.posX, eyePosition, this.posZ);
         IBlockState state = this.world.getBlockState(eyeBlockPos);
-        if(state.getMaterial() == Material.WATER && state.getBlock() instanceof BlockLiquid) {
-            float thresholdHeight = eyeBlockPos.getY() + BlockLiquid.getBlockLiquidHeight(state, this.world, eyeBlockPos) + (1f/9f);
-            if(eyePosition < thresholdHeight) {
+        if (state.getMaterial() == Material.WATER && state.getBlock() instanceof BlockLiquid) {
+            float thresholdHeight = eyeBlockPos.getY() + BlockLiquid.getBlockLiquidHeight(state, this.world, eyeBlockPos) + (1f / 9f);
+            if (eyePosition < thresholdHeight) {
                 applyFloatMotion();
                 return true;
             }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityLivingBaseMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityLivingBaseMixin.java
@@ -38,24 +38,24 @@ public abstract class EntityLivingBaseMixin extends Entity {
 
         return this.isSneaking();
     }
-    
+
     private boolean aqua$isLosingAir() {
-        if(ConfigHandler.MiscellaneousConfig.bubbleColumns
-                && this.world.getBlockState(new BlockPos(this.posX, this.posY + (double)this.getEyeHeight(), this.posZ)).getBlock() == CommonProxy.BUBBLE_COLUMN)
+        if (ConfigHandler.MiscellaneousConfig.bubbleColumns
+                && this.world.getBlockState(new BlockPos(this.posX, this.posY + (double) this.getEyeHeight(), this.posZ)).getBlock() == CommonProxy.BUBBLE_COLUMN)
             return false; /* pretend not to be in water */
         return this.isInsideOfMaterial(Material.WATER);
     }
 
     @Redirect(method = "onEntityUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;isInsideOfMaterial(Lnet/minecraft/block/material/Material;)Z"))
     private boolean checkBubbleBreathing(EntityLivingBase entityLivingBase, Material materialIn) {
-        if(materialIn == Material.WATER)
+        if (materialIn == Material.WATER)
             return aqua$isLosingAir();
         return entityLivingBase.isInsideOfMaterial(materialIn);
     }
-    
+
     @ModifyArg(method = "onEntityUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;setAir(I)V"), index = 0)
     private int getNewAirValue(int original) {
-        if(ConfigHandler.MiscellaneousConfig.slowAirReplenish && original == 300 && this.getAir() >= -20 && !aqua$isLosingAir()) {
+        if (ConfigHandler.MiscellaneousConfig.slowAirReplenish && original == 300 && this.getAir() >= -20 && !aqua$isLosingAir()) {
             int oldAirValue = Math.max(this.getAir(), 0);
             return Math.min(oldAirValue + 4, 300);
         }
@@ -64,7 +64,7 @@ public abstract class EntityLivingBaseMixin extends Entity {
 
     @Redirect(method = "travel", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;collidedHorizontally:Z", ordinal = 1))
     private boolean isJumpingOnLadder(EntityLivingBase instance) {
-        if(ConfigHandler.MovementConfig.newClimbingBehavior)
+        if (ConfigHandler.MovementConfig.newClimbingBehavior)
             return instance.collidedHorizontally || ((EntityLivingBaseMixin) (Object) instance).aqua$isJumping();
         else
             return instance.collidedHorizontally;

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityMixin.java
@@ -32,8 +32,9 @@ public abstract class EntityMixin implements IBubbleColumnInteractable {
     @Shadow
     public float fallDistance;
 
-    @Shadow public World world;
-    
+    @Shadow
+    public World world;
+
     @Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;isSneaking()Z"))
     public boolean isSneaking(Entity entity) {
 
@@ -48,7 +49,7 @@ public abstract class EntityMixin implements IBubbleColumnInteractable {
 
     @Override
     public void onEnterBubbleColumn(boolean downwards) {
-        if(!downwards) {
+        if (!downwards) {
             this.motionY = Math.min(0.7, this.motionY + 0.06);
         } else
             this.motionY = Math.max(-0.3, this.motionY - 0.03);
@@ -57,7 +58,7 @@ public abstract class EntityMixin implements IBubbleColumnInteractable {
 
     @Override
     public void onEnterBubbleColumnWithAirAbove(boolean downwards) {
-        if(!downwards) {
+        if (!downwards) {
             this.motionY = Math.min(1.8, this.motionY + 0.1);
         } else
             this.motionY = Math.max(-0.9, this.motionY - 0.03);
@@ -65,7 +66,7 @@ public abstract class EntityMixin implements IBubbleColumnInteractable {
 
     @ModifyVariable(method = "move", ordinal = 0, name = "block", at = @At("LOAD"))
     private Block getFakeClimbingBlock(Block original) {
-        if(ConfigHandler.MovementConfig.newClimbingBehavior && original instanceof BlockVine)
+        if (ConfigHandler.MovementConfig.newClimbingBehavior && original instanceof BlockVine)
             return Blocks.LADDER;
         return original;
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityPlayerMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityPlayerMixin.java
@@ -77,7 +77,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
     private float swimAnimation;
     private float lastSwimAnimation;
     private float timeUnderwater;
-    
+
     private boolean inBubbleColumn;
 
     public EntityPlayerMixin(World worldIn) {
@@ -87,25 +87,25 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
 
     private float findEntitySizeScaleFactor() {
         float finalFactor = 1f;
-        if(IntegrationManager.isTrinketsAndBaublesEnabled())
-            finalFactor *= TrinketsAndBaublesIntegration.getResizeFactor((EntityPlayer)(Object)this);
-        if(IntegrationManager.isChiseledMeEnabled())
-            finalFactor *= ChiseledMeIntegration.getResizeFactor((EntityPlayer)(Object)this);
+        if (IntegrationManager.isTrinketsAndBaublesEnabled())
+            finalFactor *= TrinketsAndBaublesIntegration.getResizeFactor((EntityPlayer) (Object) this);
+        if (IntegrationManager.isChiseledMeEnabled())
+            finalFactor *= ChiseledMeIntegration.getResizeFactor((EntityPlayer) (Object) this);
         return finalFactor;
     }
 
     private float findEyeScaleFactor() {
         float finalFactor = 1f;
-        if(IntegrationManager.isArtemisLibEnabled())
-            finalFactor *= ArtemisLibIntegration.getEyeFactor((EntityPlayer)(Object)this);
-        if(IntegrationManager.isChiseledMeEnabled())
-            finalFactor *= ChiseledMeIntegration.getResizeFactor((EntityPlayer)(Object)this);
+        if (IntegrationManager.isArtemisLibEnabled())
+            finalFactor *= ArtemisLibIntegration.getEyeFactor((EntityPlayer) (Object) this);
+        if (IntegrationManager.isChiseledMeEnabled())
+            finalFactor *= ChiseledMeIntegration.getResizeFactor((EntityPlayer) (Object) this);
         return finalFactor;
     }
 
     private EntitySize handleEntitySizeScaling(EntitySize in) {
         float finalFactor = findEntitySizeScaleFactor();
-        if(finalFactor == 1f)
+        if (finalFactor == 1f)
             return in;
         else
             return in.scale(finalFactor);
@@ -170,7 +170,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
                 return 1.0f;
             } else {
                 float f2 = MathHelper.clamp(this.timeUnderwater / 100.0f, 0.0f, 1.0f);
-                float f3 = this.timeUnderwater < 100.0f ? 0.0f : MathHelper.clamp(((float)this.timeUnderwater - 100.0f) / 500.0f, 0.0f, 1.0f);
+                float f3 = this.timeUnderwater < 100.0f ? 0.0f : MathHelper.clamp(((float) this.timeUnderwater - 100.0f) / 500.0f, 0.0f, 1.0f);
                 return f2 * 0.6f + f3 * 0.39999998f;
             }
         }
@@ -188,7 +188,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
 
     @Override
     public void setForcingCrawling(boolean flag) {
-        if(!this.canForceCrawling())
+        if (!this.canForceCrawling())
             return;
         this.dataManager.set(TOGGLED_CRAWLING, flag);
     }
@@ -316,14 +316,14 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
     }
 
     protected float getEyeHeight(Pose poseIn, EntitySize sizeIn) {
-        if(IntegrationManager.isWitcheryResurrectedEnabled()) {
+        if (IntegrationManager.isWitcheryResurrectedEnabled()) {
             switch (WitcheryResurrectedIntegration.getCurrentTransformation()) {
                 case BAT:
                 case WOLF:
                     return 0.5f;
             }
         }
-        return poseIn == Pose.SLEEPING || poseIn ==  Pose.DYING ? 0.2F : this.getStandingEyeHeight(poseIn, sizeIn);
+        return poseIn == Pose.SLEEPING || poseIn == Pose.DYING ? 0.2F : this.getStandingEyeHeight(poseIn, sizeIn);
     }
 
     @Override
@@ -335,7 +335,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
     @Override
     public float getStandingEyeHeight(Pose poseIn, EntitySize sizeIn) {
 
-        switch(poseIn) {
+        switch (poseIn) {
 
             case SWIMMING:
             case FALL_FLYING:
@@ -371,7 +371,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
 
     @Override
     public boolean isPoseClear(Pose poseIn) {
-        if(poseIn == Pose.CROUCHING && IntegrationManager.isBetweenlandsEnabled() && BetweenlandsIntegration.couldPlayerPhase((EntityPlayer)(Object)this))
+        if (poseIn == Pose.CROUCHING && IntegrationManager.isBetweenlandsEnabled() && BetweenlandsIntegration.couldPlayerPhase((EntityPlayer) (Object) this))
             return true;
         return this.world.getCollisionBoxes(this, this.getBoundingBox(poseIn)).isEmpty();
     }
@@ -435,7 +435,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
 
                     pose1 = Pose.CROUCHING;
                 } else {
-                    if(ConfigHandler.MovementConfig.enableCrawling)
+                    if (ConfigHandler.MovementConfig.enableCrawling)
                         pose1 = Pose.SWIMMING;
                     else
                         pose1 = Pose.STANDING;
@@ -458,7 +458,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBase implements IPla
     }
 
     protected AxisAlignedBB getBoundingBox(Pose p_213321_1_) {
-        
+
         EntitySize entitysize = this.getSize(p_213321_1_);
         float f = entitysize.width / 2.0F;
         return new AxisAlignedBB(this.posX - (double) f, this.posY, this.posZ - (double) f, this.posX + (double) f, this.posY + (double) entitysize.height, this.posZ + (double) f);

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityThrowableMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/EntityThrowableMixin.java
@@ -27,14 +27,15 @@ public abstract class EntityThrowableMixin extends Entity {
 
     @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;rayTraceBlocks(Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/RayTraceResult;"))
     private RayTraceResult rayTraceThroughLiquid(World world, Vec3d start, Vec3d end) {
-        if(aqua$isNewProjectile)
+        if (aqua$isNewProjectile)
             return world.rayTraceBlocks(start, end, false, true, false);
         else
             return world.rayTraceBlocks(start, end);
     }
+
     @Inject(method = "onUpdate", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/projectile/EntityThrowable;posX:D", opcode = Opcodes.PUTFIELD, ordinal = 0))
     private void doCheckBlockCollision(CallbackInfo ci) {
-        if(aqua$isNewProjectile)
+        if (aqua$isNewProjectile)
             this.doBlockCollisions();
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/accessor/FluidAccessor.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/accessor/FluidAccessor.java
@@ -11,6 +11,7 @@ public interface FluidAccessor {
     @Accessor(value = "still", remap = false)
     @Mutable
     void setStillTexture(ResourceLocation rl);
+
     @Accessor(value = "flowing", remap = false)
     @Mutable
     void setFlowingTexture(ResourceLocation rl);

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockAliasesBubbleColumnMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockAliasesBubbleColumnMixin.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class BlockAliasesBubbleColumnMixin {
     /**
      * @author embeddedt
-     * Reason: inject the bubble column into the block aliases.
+     * @reason inject the bubble column into the block aliases
      */
     @Inject(method = "loadBlockAliases", at = @At("RETURN"), remap = false)
     private static void injectAABubbleColumn(InputStream in, String path, List<List<?>> listBlockAliases, CallbackInfo ci) {

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockAliasesBubbleColumnMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockAliasesBubbleColumnMixin.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class BlockAliasesBubbleColumnMixin {
     /**
      * @author embeddedt
-     * @reason inject the bubble column into the block aliases
+     * Reason: inject the bubble column into the block aliases.
      */
     @Inject(method = "loadBlockAliases", at = @At("RETURN"), remap = false)
     private static void injectAABubbleColumn(InputStream in, String path, List<List<?>> listBlockAliases, CallbackInfo ci) {

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockFluidRendererMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/BlockFluidRendererMixin.java
@@ -16,15 +16,17 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(BlockFluidRenderer.class)
 public class BlockFluidRendererMixin {
-    @Shadow @Final private BlockColors blockColors;
-    
-    
+    @Shadow
+    @Final
+    private BlockColors blockColors;
+
+
     @ModifyConstant(
             method = "initAtlasSprites",
             constant = @Constant(stringValue = "minecraft:blocks/water_still")
     )
     private String getWaterStillTexture(String old) {
-        if(ConfigHandler.BlocksConfig.newWaterColors)
+        if (ConfigHandler.BlocksConfig.newWaterColors)
             return "aquaacrobatics:blocks/water_still";
         else
             return old;
@@ -35,18 +37,18 @@ public class BlockFluidRendererMixin {
             constant = @Constant(stringValue = "minecraft:blocks/water_flow")
     )
     private String getWaterFlowTexture(String old) {
-        if(ConfigHandler.BlocksConfig.newWaterColors)
+        if (ConfigHandler.BlocksConfig.newWaterColors)
             return "aquaacrobatics:blocks/water_flow";
         else
             return old;
     }
-    
+
 
     @ModifyArgs(
             method = "renderFluid", at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/BufferBuilder;color(FFFF)Lnet/minecraft/client/renderer/BufferBuilder;"
-            ),
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/BufferBuilder;color(FFFF)Lnet/minecraft/client/renderer/BufferBuilder;"
+    ),
             slice = @Slice(
                     from = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/BlockPos;down()Lnet/minecraft/util/math/BlockPos;", ordinal = 0),
                     to = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/BlockPos;add(III)Lnet/minecraft/util/math/BlockPos;", ordinal = 0)
@@ -55,15 +57,15 @@ public class BlockFluidRendererMixin {
             require = 4
     )
     private void overrideColorForBottomFace(Args args, IBlockAccess blockAccess, IBlockState blockStateIn, BlockPos blockPosIn, BufferBuilder bufferBuilderIn) {
-        if(blockStateIn.getMaterial() == Material.WATER && ((Float)args.get(1)) == 0.5f && ((Float)args.get(2)) == 0.5f) {
+        if (blockStateIn.getMaterial() == Material.WATER && ((Float) args.get(1)) == 0.5f && ((Float) args.get(2)) == 0.5f) {
             int i = blockColors.colorMultiplier(blockStateIn, blockAccess, blockPosIn, 0);
-            float f = (float)(i >> 16 & 255) / 255.0F;
-            float f1 = (float)(i >> 8 & 255) / 255.0F;
-            float f2 = (float)(i & 255) / 255.0F;
+            float f = (float) (i >> 16 & 255) / 255.0F;
+            float f1 = (float) (i >> 8 & 255) / 255.0F;
+            float f2 = (float) (i & 255) / 255.0F;
             args.set(0, f);
             args.set(1, f1);
             args.set(2, f2);
-            args.set(3, 1.0f);   
+            args.set(3, 1.0f);
         }
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityPlayerSPMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityPlayerSPMixin.java
@@ -25,6 +25,7 @@ import net.minecraft.util.MovementInput;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -215,6 +216,7 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
         return StreamSupport.stream(new AxisAlignedBBSpliterator(world, entity, aabb), false);
     }
 
+    @Dynamic
     @Redirect(method = { "pushOutOfBlocks", "localPushOutOfBlocks" }, at = @At(value = "INVOKE", target = "Ljava/lang/Math;ceil(D)D"))
     private double ceil(double a) {
 
@@ -273,6 +275,7 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
         return false;
     }
 
+    @Dynamic
     @Inject(method = { "onLivingUpdate", "localOnLivingUpdate" }, at = @At(value = "FIELD", target = "Lnet/minecraft/client/entity/EntityPlayerSP;wasFallFlying:Z"))
     public void onLivingUpdate(CallbackInfo callbackInfo) {
 

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityPlayerSPMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityPlayerSPMixin.java
@@ -217,7 +217,7 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
     }
 
     @Dynamic
-    @Redirect(method = { "pushOutOfBlocks", "localPushOutOfBlocks" }, at = @At(value = "INVOKE", target = "Ljava/lang/Math;ceil(D)D"))
+    @Redirect(method = {"pushOutOfBlocks", "localPushOutOfBlocks"}, at = @At(value = "INVOKE", target = "Ljava/lang/Math;ceil(D)D"))
     private double ceil(double a) {
 
         if (ConfigHandler.playerBlockCollisions == ConfigHandler.PlayerBlockCollisions.APPROXIMATE) {
@@ -276,14 +276,14 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
     }
 
     @Dynamic
-    @Inject(method = { "onLivingUpdate", "localOnLivingUpdate" }, at = @At(value = "FIELD", target = "Lnet/minecraft/client/entity/EntityPlayerSP;wasFallFlying:Z"))
+    @Inject(method = {"onLivingUpdate", "localOnLivingUpdate"}, at = @At(value = "FIELD", target = "Lnet/minecraft/client/entity/EntityPlayerSP;wasFallFlying:Z"))
     public void onLivingUpdate(CallbackInfo callbackInfo) {
 
         this.updatePlayerMoveState();
         this.isCrouching = this.isCrouching(!((IPlayerResizeable) this).isPoseClear(Pose.STANDING));
         // handle sprinting behaviour
         this.setSprinting(this.movementStorage.isSprinting);
-        boolean isSaturated = (float)this.getFoodStats().getFoodLevel() > 6.0F || this.capabilities.allowFlying;
+        boolean isSaturated = (float) this.getFoodStats().getFoodLevel() > 6.0F || this.capabilities.allowFlying;
         this.startSprinting(isSaturated);
         this.stopSprinting(isSaturated);
         // handle misc movement
@@ -363,7 +363,7 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
             }
         }
     }
-    
+
     @Override
     public boolean canPerformElytraTakeoff() {
         return (ConfigHandler.MovementConfig.easyElytraTakeoff && this.movementInput.jump && !this.movementStorage.isStartingToFly && !this.movementStorage.jump && this.motionY >= 0.0 && !this.capabilities.isFlying && !this.isRiding() && !this.isOnLadder());
@@ -377,7 +377,7 @@ public abstract class EntityPlayerSPMixin extends AbstractClientPlayer implement
             if (itemstack.getItem() == Items.ELYTRA && ItemElytra.isUsable(itemstack)) {
                 this.connection.sendPacket(new CPacketEntityAction(this, CPacketEntityAction.Action.START_FALL_FLYING));
             } else {
-                IntegrationManager.elytraOpenHooks.forEach(hook -> hook.openElytra((EntityPlayerSP) (Object)this));
+                IntegrationManager.elytraOpenHooks.forEach(hook -> hook.openElytra((EntityPlayerSP) (Object) this));
             }
         }
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityRendererMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityRendererMixin.java
@@ -75,7 +75,7 @@ public abstract class EntityRendererMixin {
     )
     private boolean ignoreWater(Entity entity, Material material) {
         /* 1.13 removed this check */
-        if(material == Material.WATER)
+        if (material == Material.WATER)
             return false;
         return entity.isInsideOfMaterial(material);
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityRendererMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/EntityRendererMixin.java
@@ -2,15 +2,24 @@ package com.fuzs.aquaacrobatics.core.mixin.client;
 
 import com.fuzs.aquaacrobatics.integration.IntegrationManager;
 import com.fuzs.aquaacrobatics.util.math.MathHelperNew;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.entity.Entity;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.IFluidBlock;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -59,6 +68,79 @@ public abstract class EntityRendererMixin {
         this.previousEyeHeight = this.eyeHeight;
         this.eyeHeight += (this.entityEyeHeight - this.eyeHeight) * 0.5F;
     }
+
+    // Backport start: Camera logic from modern versions
+    @Redirect(
+            method = {"updateFogColor", "setupFog", "getFOVModifier"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/ActiveRenderInfo;getBlockStateAtEntityViewpoint(Lnet/minecraft/world/World;Lnet/minecraft/entity/Entity;F)Lnet/minecraft/block/state/IBlockState;"
+            )
+    )
+    private IBlockState getBlockStateAtCameraForFog(World world, Entity entity, float partialTicks) {
+        IBlockState state = ActiveRenderInfo.getBlockStateAtEntityViewpoint(world, entity, partialTicks);
+        if (state.getMaterial() == Material.WATER && !this.aquaAcrobatics$isCameraInWater(world, entity, partialTicks)) {
+            return Blocks.AIR.getDefaultState();
+        }
+        return state;
+    }
+
+    @Redirect(
+            method = "updateFogColor",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;getFogColor(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;F)Lnet/minecraft/util/math/Vec3d;"
+            )
+    )
+    private Vec3d getFogColor(Block block, World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
+        if (state.getMaterial() == Material.WATER && !this.aquaAcrobatics$isCameraInWater(world, entity, partialTicks)) {
+            return originalColor;
+        }
+        return block.getFogColor(world, pos, state, entity, originalColor, partialTicks);
+    }
+
+    @Unique
+    private boolean aquaAcrobatics$isCameraInWater(World world, Entity entity, float partialTicks) {
+        Vec3d cameraPos = this.aquaAcrobatics$getCameraPosition(entity, partialTicks);
+        BlockPos blockPos = new BlockPos(cameraPos);
+        IBlockState state = world.getBlockState(blockPos);
+        if (state.getMaterial() != Material.WATER) {
+            return false;
+        }
+
+        return cameraPos.y < (double) blockPos.getY() + this.aquaAcrobatics$getWaterHeight(world, blockPos, state);
+    }
+
+    @Unique
+    private Vec3d aquaAcrobatics$getCameraPosition(Entity entity, float partialTicks) {
+        double x = entity.prevPosX + (entity.posX - entity.prevPosX) * (double) partialTicks;
+        double y = entity.prevPosY + (entity.posY - entity.prevPosY) * (double) partialTicks;
+        double z = entity.prevPosZ + (entity.posZ - entity.prevPosZ) * (double) partialTicks;
+        return new Vec3d(x, y + (double) this.aquaAcrobatics$getCameraEyeHeight(entity, partialTicks), z);
+    }
+
+    @Unique
+    private float aquaAcrobatics$getCameraEyeHeight(Entity entity, float partialTicks) {
+        if (entity instanceof EntityPlayer && !IntegrationManager.isRandomPatchesEnabled()) {
+            return MathHelperNew.lerp(partialTicks, this.previousEyeHeight, this.eyeHeight);
+        }
+        return entity.getEyeHeight();
+    }
+
+    @Unique
+    private float aquaAcrobatics$getWaterHeight(World world, BlockPos pos, IBlockState state) {
+        Block block = state.getBlock();
+        if (block instanceof IFluidBlock) {
+            float filled = ((IFluidBlock) block).getFilledPercentage(world, pos);
+            return filled < 0.0F ? filled + 1.0F : filled;
+        }
+        if (block instanceof BlockLiquid) {
+            return BlockLiquid.getBlockLiquidHeight(state, world, pos);
+        }
+        float height = block.getBlockLiquidHeight(world, pos, state, Material.WATER);
+        return height > 0.0F ? height : 1.0F;
+    }
+    // Backport end - Camera logic from modern versions
 
     /**
      * This mixin is marked as not required, as some mods patch this themselves.

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ItemRendererMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ItemRendererMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public abstract class ItemRendererMixin {
     @ModifyArg(method = "renderWaterOverlayTexture", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;color(FFFF)V", ordinal = 0), index = 3)
     private float replaceOpacity(float originalOpacity) {
-        if(ConfigHandler.BlocksConfig.newWaterColors)
+        if (ConfigHandler.BlocksConfig.newWaterColors)
             return 0.1f;
         else
             return originalOpacity;

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ModelBipedMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ModelBipedMixin.java
@@ -90,7 +90,7 @@ public abstract class ModelBipedMixin extends ModelBase implements IModelBipedSw
                 float f = 1.0F - (float) Math.pow(useRatio, 27.0D);
                 if (useRatio < 0.8F) {
 
-                    f += MathHelper.abs(MathHelper.cos(animationCount / 4.0F * (float)Math.PI) * 0.1F);
+                    f += MathHelper.abs(MathHelper.cos(animationCount / 4.0F * (float) Math.PI) * 0.1F);
                 }
 
                 ModelRenderer bipedArm = isRight ? this.bipedRightArm : this.bipedLeftArm;

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ModelFluidMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/ModelFluidMixin.java
@@ -12,19 +12,19 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(ModelFluid.class)
 public class ModelFluidMixin {
     private ResourceLocation aqua$getRealStill(Fluid fluid) {
-        if(ConfigHandler.BlocksConfig.newWaterColors && fluid == FluidRegistry.WATER)
+        if (ConfigHandler.BlocksConfig.newWaterColors && fluid == FluidRegistry.WATER)
             return new ResourceLocation("aquaacrobatics:blocks/water_still");
         else
             return fluid.getStill();
     }
 
     private ResourceLocation aqua$getRealFlowing(Fluid fluid) {
-        if(ConfigHandler.BlocksConfig.newWaterColors && fluid == FluidRegistry.WATER)
+        if (ConfigHandler.BlocksConfig.newWaterColors && fluid == FluidRegistry.WATER)
             return new ResourceLocation("aquaacrobatics:blocks/water_flow");
         else
             return fluid.getFlowing();
     }
-    
+
     @Redirect(method = "getTextures", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fluids/Fluid;getStill()Lnet/minecraft/util/ResourceLocation;"), remap = false)
     private ResourceLocation getTextures_RealStill(Fluid fluid) {
         return aqua$getRealStill(fluid);

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/RenderBoatMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/RenderBoatMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class RenderBoatMixin {
     @Inject(method = "setupRotation", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;scale(FFF)V", shift = At.Shift.BEFORE))
     private void addRockingRotation(EntityBoat boat, float entityYaw, float partialTicks, CallbackInfo ci) {
-        float f2 = ((IRockableBoat)boat).getRockingAngle(partialTicks);
+        float f2 = ((IRockableBoat) boat).getRockingAngle(partialTicks);
         if (!MathHelper.epsilonEquals(f2, 0.0F)) {
             GlStateManager.rotate(f2, 1.0F, 0.0F, 1.0F);
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/RenderGlobalMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/mixin/client/RenderGlobalMixin.java
@@ -1,0 +1,21 @@
+package com.fuzs.aquaacrobatics.core.mixin.client;
+
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.RenderGlobal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RenderGlobal.class)
+public abstract class RenderGlobalMixin {
+    @Redirect(
+            method = "renderSky(FI)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/multiplayer/WorldClient;getHorizon()D"
+            )
+    )
+    public double getHorizon(WorldClient instance) {
+        return 0.0D;
+    }
+}

--- a/src/main/java/com/fuzs/aquaacrobatics/core/thaumcraft/mixin/client/TileCrucibleRendererMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/thaumcraft/mixin/client/TileCrucibleRendererMixin.java
@@ -14,7 +14,7 @@ import thaumcraft.client.renderers.tile.TileCrucibleRenderer;
 public class TileCrucibleRendererMixin {
     @Redirect(method = "renderFluid", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/BlockModelShapes;getTexture(Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;"))
     private TextureAtlasSprite getLegacyWaterTexture(BlockModelShapes instance, IBlockState state) {
-        if(state == Blocks.WATER.getDefaultState())
+        if (state == Blocks.WATER.getDefaultState())
             return Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("minecraft:blocks/water_still");
         return instance.getTexture(state);
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/core/xaerosminimap/mixin/client/MinimapWriterMixin.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/core/xaerosminimap/mixin/client/MinimapWriterMixin.java
@@ -17,7 +17,7 @@ public class MinimapWriterMixin {
     @Redirect(method = "loadBlockColourFromTexture", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/BlockModelShapes;getTexture(Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;"))
     private TextureAtlasSprite useWaterTexture(BlockModelShapes instance, IBlockState state) {
         Block block = state.getBlock();
-        if(ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER))
+        if (ConfigHandler.BlocksConfig.newWaterColors && (block == Blocks.WATER || block == Blocks.FLOWING_WATER))
             return FMLClientHandler.instance().getClient().getTextureMapBlocks().getAtlasSprite("aquaacrobatics:blocks/water_still");
         else
             return instance.getTexture(state);

--- a/src/main/java/com/fuzs/aquaacrobatics/entity/IBubbleColumnInteractable.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/entity/IBubbleColumnInteractable.java
@@ -2,5 +2,6 @@ package com.fuzs.aquaacrobatics.entity;
 
 public interface IBubbleColumnInteractable {
     void onEnterBubbleColumnWithAirAbove(boolean downwards);
+
     void onEnterBubbleColumn(boolean downwards);
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/handler/CommonHandler.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/handler/CommonHandler.java
@@ -12,9 +12,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class CommonHandler {
     @SubscribeEvent
     public void onEntityConstructing(EntityEvent.EntityConstructing event) {
-        if(event.getEntity() instanceof EntityBoat) {
-            if(ConfigHandler.MiscellaneousConfig.bubbleColumns)
-                ((IRockableBoat)event.getEntity()).aqua$doRegisterData();
+        if (event.getEntity() instanceof EntityBoat) {
+            if (ConfigHandler.MiscellaneousConfig.bubbleColumns)
+                ((IRockableBoat) event.getEntity()).aqua$doRegisterData();
         }
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/IntegrationManager.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/IntegrationManager.java
@@ -101,8 +101,7 @@ public class IntegrationManager {
         return isTrinketsAndBaublesLoaded && ConfigHandler.IntegrationConfig.trinketsAndBaublesIntegration;
     }
 
-    public static boolean isWitcheryResurrectedEnabled()
-    {
+    public static boolean isWitcheryResurrectedEnabled() {
         return isWitcheryResurrectedLoaded && ConfigHandler.IntegrationConfig.witcheryResurrectedIntegration;
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/artemislib/ArtemisLibIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/artemislib/ArtemisLibIntegration.java
@@ -43,9 +43,9 @@ public class ArtemisLibIntegration {
     }
 
     public static float getEyeFactor(EntityPlayer player) {
-        if(((IPlayerResizeable)player).getPose() == Pose.SWIMMING) {
+        if (((IPlayerResizeable) player).getPose() == Pose.SWIMMING) {
             double heightAttribute = player.getAttributeMap().getAttributeInstance(ArtemisLibAttributes.ENTITY_HEIGHT).getAttributeValue();
-            return (float)(heightAttribute * 3);
+            return (float) (heightAttribute * 3);
         }
         return 1f;
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/artemislib/AttachAttributesFix.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/artemislib/AttachAttributesFix.java
@@ -42,7 +42,7 @@ public class AttachAttributesFix extends AttachAttributes {
     @Override
     @SubscribeEvent
     public void onEntityRenderPre(final RenderLivingEvent.Pre evt) {
-        
+
         EntityLivingBase entity = evt.getEntity();
         this.updateResizingFlag(entity);
         if (this.isResizingRequired) {

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/betweenlands/BetweenlandsIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/betweenlands/BetweenlandsIntegration.java
@@ -7,6 +7,7 @@ import thebetweenlands.common.capability.collision.RingOfDispersionEntityCapabil
 public class BetweenlandsIntegration {
     /**
      * Checks if the player is potentially able to phase at some point.
+     *
      * @param player player to check
      * @return true if the player is potentially able to phase
      */

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/betweenlands/BetweenlandsIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/betweenlands/BetweenlandsIntegration.java
@@ -7,11 +7,14 @@ import thebetweenlands.common.capability.collision.RingOfDispersionEntityCapabil
 public class BetweenlandsIntegration {
     /**
      * Checks if the player is potentially able to phase at some point.
+     * @param player player to check
+     * @return true if the player is potentially able to phase
      */
     public static boolean couldPlayerPhase(EntityPlayer player) {
         ItemStack ring = RingOfDispersionEntityCapability.getRing(player);
-        if(ring == ItemStack.EMPTY)
+        if (ring == ItemStack.EMPTY) {
             return false;
+        }
         return ring.getItemDamage() < ring.getMaxDamage() && !player.isSpectator();
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/chiseledme/ChiseledMeIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/chiseledme/ChiseledMeIntegration.java
@@ -5,6 +5,6 @@ import net.minecraft.entity.player.EntityPlayer;
 
 public class ChiseledMeIntegration {
     public static float getResizeFactor(EntityPlayer player) {
-        return (float)((ISized)player).getSizeCM();
+        return (float) ((ISized) player).getSizeCM();
     }
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/enderio/EnderIOIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/enderio/EnderIOIntegration.java
@@ -7,7 +7,7 @@ import crazypants.enderio.base.item.darksteel.upgrade.elytra.ElytraUpgrade;
 public class EnderIOIntegration {
     public static void register() {
         IntegrationManager.elytraOpenHooks.add(player -> {
-            if(!StateController.isActive(player, ElytraUpgrade.INSTANCE)) {
+            if (!StateController.isActive(player, ElytraUpgrade.INSTANCE)) {
                 StateController.setActive(player, ElytraUpgrade.INSTANCE, true);
             }
         });

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/trinketsandbaubles/TrinketsAndBaublesIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/trinketsandbaubles/TrinketsAndBaublesIntegration.java
@@ -7,8 +7,8 @@ import xzeroair.trinkets.capabilities.race.EntityProperties;
 public class TrinketsAndBaublesIntegration {
     public static float getResizeFactor(EntityPlayer player) {
         EntityProperties props = Capabilities.getEntityRace(player);
-        if(props != null)
-            return (float)props.getSize() / 100f;
+        if (props != null)
+            return (float) props.getSize() / 100f;
         else
             return 1f;
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/wings/WingsIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/wings/WingsIntegration.java
@@ -8,10 +8,10 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 public class WingsIntegration {
 
     public static boolean onFlightCheck(EntityPlayer player, boolean isElytraFlying) {
-        
+
         PlayerFlightCheckEvent evt = new PlayerFlightCheckEvent(player);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.getResult() == Event.Result.ALLOW || evt.getResult() == Event.Result.DEFAULT && isElytraFlying;
     }
-    
+
 }

--- a/src/main/java/com/fuzs/aquaacrobatics/integration/witchery/WitcheryResurrectedIntegration.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/integration/witchery/WitcheryResurrectedIntegration.java
@@ -7,8 +7,7 @@ import net.msrandom.witchery.init.data.WitcheryAlternateForms;
 import net.msrandom.witchery.transformation.CreatureForm;
 import net.msrandom.witchery.util.WitcheryUtils;
 
-public class WitcheryResurrectedIntegration
-{
+public class WitcheryResurrectedIntegration {
     public static boolean HAS_TRANSFORMED = false;
 
     private static Transformation currentTransformation = Transformation.PLAYER;
@@ -30,8 +29,7 @@ public class WitcheryResurrectedIntegration
         });
     }
 
-    public static Transformation getCurrentTransformation()
-    {
+    public static Transformation getCurrentTransformation() {
         return currentTransformation;
     }
 

--- a/src/main/java/com/fuzs/aquaacrobatics/network/message/PacketSendKey.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/network/message/PacketSendKey.java
@@ -13,12 +13,13 @@ public class PacketSendKey implements IMessage {
         UNKNOWN,
         TOGGLE_CRAWLING
     }
+
     private KeybindPacket keybind = KeybindPacket.UNKNOWN;
 
     @Override
     public void fromBytes(ByteBuf buf) {
         int idx = buf.readInt();
-        if(idx >= KeybindPacket.values().length)
+        if (idx >= KeybindPacket.values().length)
             keybind = KeybindPacket.UNKNOWN;
         else
             keybind = KeybindPacket.values()[idx];
@@ -50,8 +51,8 @@ public class PacketSendKey implements IMessage {
 
         private void handle(PacketSendKey message, MessageContext ctx) {
             EntityPlayerMP playerEntity = ctx.getServerHandler().player;
-            if(message.keybind == KeybindPacket.TOGGLE_CRAWLING) {
-                IPlayerResizeable resizeable = (IPlayerResizeable)playerEntity;
+            if (message.keybind == KeybindPacket.TOGGLE_CRAWLING) {
+                IPlayerResizeable resizeable = (IPlayerResizeable) playerEntity;
                 resizeable.setForcingCrawling(!resizeable.isForcingCrawling());
             }
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/optifine/OptifineHelper.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/optifine/OptifineHelper.java
@@ -14,7 +14,7 @@ public class OptifineHelper {
         Class<?> reflectorMainClass;
         try {
             reflectorMainClass = Class.forName("net.optifine.reflect.Reflector");
-        } catch(ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             return;
         }
         AquaAcrobatics.LOGGER.info("OptiFine detected. Performing highly invasive tweaks to fix water issues.");
@@ -24,7 +24,7 @@ public class OptifineHelper {
             Field biomeMethodField = reflectorMainClass.getDeclaredField("ForgeBiome_getWaterColorMultiplier");
             biomeMethodField.setAccessible(true);
             biomeMethodField.set(null, newReflectorMethod);
-        } catch(ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException e) {
             AquaAcrobatics.LOGGER.error("An error occured while patching OptiFine", e);
             return;
         }
@@ -50,7 +50,7 @@ public class OptifineHelper {
     /**
      * Rewrite an OptiFine shader block alias to use the same metadata filters but a different main block ID.
      *
-     * @param mainId the replacement main block ID
+     * @param mainId     the replacement main block ID
      * @param blockAlias the OptiFine block alias to rewrite
      * @return the rewritten block alias, or the original alias if rewriting fails
      */
@@ -75,13 +75,13 @@ public class OptifineHelper {
             Object newMatchArray = Array.newInstance(matchBlockClass, numMatches);
             for (int i = 0; i < numMatches; i++) {
                 Object match = Array.get(matchArray, i);
-                int[] metadatas = (int[])metadatasField.get(match);
+                int[] metadatas = (int[]) metadatasField.get(match);
                 Object newMatch = matchBlockConstructor.newInstance(mainId, metadatas);
                 Array.set(newMatchArray, i, newMatch);
             }
             Constructor<?> blockAliasConstructor = blockAlias.getClass().getDeclaredConstructor(int.class, newMatchArray.getClass());
             return blockAliasConstructor.newInstance(blockAliasId, newMatchArray);
-        } catch(Exception e) {
+        } catch (Exception e) {
             AquaAcrobatics.LOGGER.error("An error occured while patching OptiFine", e);
             return blockAlias;
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/optifine/OptifineHelper.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/optifine/OptifineHelper.java
@@ -49,6 +49,10 @@ public class OptifineHelper {
 
     /**
      * Rewrite an OptiFine shader block alias to use the same metadata filters but a different main block ID.
+     *
+     * @param mainId the replacement main block ID
+     * @param blockAlias the OptiFine block alias to rewrite
+     * @return the rewritten block alias, or the original alias if rewriting fails
      */
     public static Object rewriteBlockAliasForNewId(int mainId, Object blockAlias) {
         if (blockAlias == null) {

--- a/src/main/java/com/fuzs/aquaacrobatics/proxy/ClientProxy.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/proxy/ClientProxy.java
@@ -89,7 +89,8 @@ public class ClientProxy extends CommonProxy {
 
     @SubscribeEvent
     public static void onKeyPress(InputEvent.KeyInputEvent event) {
-        if (ConfigHandler.MovementConfig.enableToggleCrawling && Keybindings.forceCrawling.isPressed()) {
+                                                                // null check for hot reload
+        if (ConfigHandler.MovementConfig.enableToggleCrawling && Keybindings.forceCrawling != null && Keybindings.forceCrawling.isPressed()) {
             IPlayerResizeable player = (IPlayerResizeable) Minecraft.getMinecraft().player;
             if (player != null) {
                 if (player.canForceCrawling())

--- a/src/main/java/com/fuzs/aquaacrobatics/proxy/ClientProxy.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/proxy/ClientProxy.java
@@ -50,7 +50,7 @@ public class ClientProxy extends CommonProxy {
         MinecraftForge.EVENT_BUS.register(new AirMeterHandler());
         MinecraftForge.EVENT_BUS.register(new FogHandler());
 
-        if(ConfigHandler.BlocksConfig.newWaterColors) {
+        if (ConfigHandler.BlocksConfig.newWaterColors) {
             List<IResourcePack> packs = ObfuscationReflectionHelper.getPrivateValue(Minecraft.class, Minecraft.getMinecraft(), "field_110449_ao");
             packs.add(new WaterResourcePack(event.getSourceFile()));
             FMLClientHandler.instance().refreshResources(VanillaResourceType.TEXTURES);
@@ -73,13 +73,13 @@ public class ClientProxy extends CommonProxy {
 
     @SubscribeEvent
     public static void registerModels(ModelRegistryEvent event) {
-        if(ConfigHandler.MiscellaneousConfig.bubbleColumns)
+        if (ConfigHandler.MiscellaneousConfig.bubbleColumns)
             ModelLoader.setCustomStateMapper(CommonProxy.BUBBLE_COLUMN, new StateMap.Builder().ignore(BlockLiquid.LEVEL, BlockBubbleColumn.DRAG).build());
     }
-    
+
     @SubscribeEvent
     public static void registerTextures(TextureStitchEvent.Pre event) {
-        if(ConfigHandler.BlocksConfig.newWaterColors) {
+        if (ConfigHandler.BlocksConfig.newWaterColors) {
             TextureMap map = event.getMap();
             /* Register the custom 1.13-style texture used by most in-world renderers */
             map.registerSprite(new ResourceLocation("aquaacrobatics:blocks/water_still"));
@@ -89,13 +89,13 @@ public class ClientProxy extends CommonProxy {
 
     @SubscribeEvent
     public static void onKeyPress(InputEvent.KeyInputEvent event) {
-        if(ConfigHandler.MovementConfig.enableToggleCrawling && Keybindings.forceCrawling.isPressed()) {
+        if (ConfigHandler.MovementConfig.enableToggleCrawling && Keybindings.forceCrawling.isPressed()) {
             IPlayerResizeable player = (IPlayerResizeable) Minecraft.getMinecraft().player;
-            if(player != null) {
-                if(player.canForceCrawling())
+            if (player != null) {
+                if (player.canForceCrawling())
                     NetworkHandler.INSTANCE.sendToServer(new PacketSendKey(PacketSendKey.KeybindPacket.TOGGLE_CRAWLING));
                 else {
-                    ((EntityPlayerSP)player).sendMessage(new TextComponentTranslation("chat.aquaacrobatics.cannot_toggle_crawling"));
+                    ((EntityPlayerSP) player).sendMessage(new TextComponentTranslation("chat.aquaacrobatics.cannot_toggle_crawling"));
                 }
             }
         }
@@ -116,11 +116,11 @@ public class ClientProxy extends CommonProxy {
             ArtemisLibIntegration.register();
         }
 
-        if(IntegrationManager.isEnderIoEnabled()) {
+        if (IntegrationManager.isEnderIoEnabled()) {
             EnderIOIntegration.register();
         }
 
-        if(IntegrationManager.isThaumicAugmentationEnabled()) {
+        if (IntegrationManager.isThaumicAugmentationEnabled()) {
             ThaumicAugmentationIntegration.register();
         }
     }

--- a/src/main/java/com/fuzs/aquaacrobatics/proxy/CommonProxy.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/proxy/CommonProxy.java
@@ -37,7 +37,7 @@ public class CommonProxy {
 
     public void onPreInit(FMLPreInitializationEvent event) {
         IntegrationManager.loadCompat();
-        if(needNetworking())
+        if (needNetworking())
             NetworkHandler.registerMessages(AquaAcrobatics.MODID);
         MinecraftForge.EVENT_BUS.register(new CommonHandler());
     }
@@ -52,7 +52,7 @@ public class CommonProxy {
 
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> event) {
-        if(ConfigHandler.MiscellaneousConfig.bubbleColumns)
+        if (ConfigHandler.MiscellaneousConfig.bubbleColumns)
             event.getRegistry().register(new BlockBubbleColumn());
     }
 
@@ -67,7 +67,7 @@ public class CommonProxy {
         if (IntegrationManager.isWitcheryResurrectedEnabled())
             WitcheryResurrectedIntegration.register();
 
-        if(!AquaAcrobaticsCore.isModCompatLoaded)
+        if (!AquaAcrobaticsCore.isModCompatLoaded)
             AquaAcrobatics.LOGGER.error("Please consider installing MixinBooter to ensure compatibility with more mods");
 
         BiomeWaterFogColors.recomputeColors();

--- a/src/main/java/com/fuzs/aquaacrobatics/util/Keybindings.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/util/Keybindings.java
@@ -5,13 +5,11 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import org.lwjgl.input.Keyboard;
 
-public class Keybindings
-{
+public class Keybindings {
     public static KeyBinding forceCrawling = null;
 
-    public static void register()
-    {
-        if(ConfigHandler.MovementConfig.enableToggleCrawling) {
+    public static void register() {
+        if (ConfigHandler.MovementConfig.enableToggleCrawling) {
             forceCrawling = new KeyBinding("key.aquaacrobatics.toggle_crawling", Keyboard.KEY_C, "key.aquaacrobatics.category");
             ClientRegistry.registerKeyBinding(forceCrawling);
         }

--- a/src/main/java/com/fuzs/aquaacrobatics/util/math/AxisAlignedBBSpliterator.java
+++ b/src/main/java/com/fuzs/aquaacrobatics/util/math/AxisAlignedBBSpliterator.java
@@ -30,12 +30,12 @@ public class AxisAlignedBBSpliterator extends Spliterators.AbstractSpliterator<A
     private final BiPredicate<IBlockState, BlockPos> statePositionPredicate;
 
     public AxisAlignedBBSpliterator(World reader, @Nullable Entity entity, AxisAlignedBB aabb) {
-        
+
         this(reader, entity, aabb, (state, pos) -> true);
     }
 
     public AxisAlignedBBSpliterator(World reader, @Nullable Entity entity, AxisAlignedBB aabb, BiPredicate<IBlockState, BlockPos> statePositionPredicate) {
-        
+
         super(Long.MAX_VALUE, Spliterator.NONNULL | Spliterator.IMMUTABLE);
         this.reader = reader;
         this.isEntityPresent = entity != null;
@@ -52,7 +52,7 @@ public class AxisAlignedBBSpliterator extends Spliterators.AbstractSpliterator<A
     }
 
     public boolean tryAdvance(Consumer<? super AxisAlignedBB> consumer) {
-        
+
         return this.isEntityPresent && this.isEntityOutsideOfBorder(consumer) || this.isAABBColliding(consumer);
     }
 
@@ -129,7 +129,7 @@ public class AxisAlignedBBSpliterator extends Spliterators.AbstractSpliterator<A
     }
 
     private boolean isEntityOutsideOfBorder(Consumer<? super AxisAlignedBB> consumer) {
-        
+
         Objects.requireNonNull(this.entity);
         this.isEntityPresent = false;
         WorldBorder worldborder = this.reader.getWorldBorder();
@@ -145,7 +145,7 @@ public class AxisAlignedBBSpliterator extends Spliterators.AbstractSpliterator<A
     }
 
     public static boolean isBoundingBoxWithinBorder(WorldBorder worldBorder, AxisAlignedBB entityBoundingBox) {
-        
+
         double minX = MathHelper.floor(worldBorder.minX());
         double minZ = MathHelper.floor(worldBorder.minZ());
         double maxX = MathHelper.ceil(worldBorder.maxX());

--- a/src/main/resources/META-INF/mixins.aquaacrobatics.json
+++ b/src/main/resources/META-INF/mixins.aquaacrobatics.json
@@ -33,6 +33,7 @@
     "client.ModelBipedMixin",
     "client.ModelFluidMixin",
     "client.RenderBoatMixin",
+    "client.RenderGlobalMixin",
     "client.RenderPlayerMixin",
     "client.PlayerControllerMPMixin"
   ],


### PR DESCRIPTION
This pull request brings a new water fog rendering mode to AA, linear fog rendering. Backported from Minecraft 1.21.7, the default one is AA's EXP2 fog rendering, users can switch between these two modes.

## Changes

### Linear Fog

- [x] Basic linear fog rendering logic
- [x] 15% view distance reduction when in swamp biomes
- [x] Dynamic scale fog distance based on view distance
- [x] ~~Cylinder fog when view distance < 96 blocks~~ (Not possible at 1.12.2, requires modern GL features)

### Fix

- Blindness factor is incorrectly calculated with current time in milliseconds, which should use potion duration.
- Fix weird black edges near the chunk border (caused by skybox rendering) (disabled by default)

## Video

### Aqua Acrobatics EXP2 Fog


https://github.com/user-attachments/assets/209b692a-5e52-48f4-8acd-ae78d24c75d6


### Backported Linear Fog (This PR)

https://github.com/user-attachments/assets/757e883d-9184-458b-ab13-f377d7200f43

### 1.21 Vanilla


https://github.com/user-attachments/assets/2520daa7-f485-4af3-82f1-0317f2112aad

